### PR TITLE
Lock transcripts & gate feedback export on semantic end; enforce patient-only responses; add evaluation validation and PDF safeguards

### DIFF
--- a/HPVSA.py
+++ b/HPVSA.py
@@ -188,6 +188,9 @@ if st.session_state.selected_persona is None:
     if st.button("Start Conversation"):
         st.session_state.selected_persona = selected
         st.session_state.chat_history = []
+        st.session_state.locked_chat_history = []
+        st.session_state.evaluation_history = []
+        st.session_state.transcript_locked = False
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         st.session_state.chat_history.append({"role": "assistant","content": f"Hello! I'm {selected}, nice to meet you today."})
@@ -255,15 +258,20 @@ if st.session_state.selected_persona is not None:
     feedback_button_label = "Finish Session & Get Feedback"
     
     if not feedback_enabled:
-        if st.session_state.turn_count < MIN_TURN_THRESHOLD:
-            st.info(f"💬 Continue the conversation (Turn {st.session_state.turn_count}/{MIN_TURN_THRESHOLD} minimum). The feedback button will be enabled after sufficient interaction.")
+        st.info("💬 Continue until a natural semantic close is reached. The feedback button unlocks only after confirmed conversation closure.")
         
     if st.button(feedback_button_label, disabled=not feedback_enabled):
+        # Lock transcript before evaluation and keep evaluation output in separate history
+        if 'locked_chat_history' not in st.session_state or not st.session_state.get('locked_chat_history'):
+            st.session_state.locked_chat_history = list(st.session_state.chat_history)
+        st.session_state.transcript_locked = True
+        if 'evaluation_history' not in st.session_state:
+            st.session_state.evaluation_history = []
         # Get current timestamp and bot name
         current_timestamp = get_formatted_utc_time()
         evaluator = "HPV Assessment Bot"
         
-        transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.chat_history])
+        transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.get('locked_chat_history', st.session_state.chat_history)])
 
         # Retrieve relevant rubric content
         retrieved_info = retrieve_knowledge("motivational interviewing feedback rubric")
@@ -300,6 +308,7 @@ if st.session_state.selected_persona is not None:
             'timestamp': current_timestamp,
             'evaluator': evaluator
         }
+        st.session_state.evaluation_history.append({'role': 'evaluator', 'content': feedback})
 
     # PDF Generation section - only show PDF download
     if st.session_state.feedback is not None:
@@ -321,7 +330,7 @@ if st.session_state.selected_persona is not None:
             pdf_buffer = generate_pdf_report(
                 student_name=validated_name,
                 raw_feedback=formatted_feedback,
-                chat_history=st.session_state.chat_history,
+                chat_history=st.session_state.get('locked_chat_history', st.session_state.chat_history),
                 session_type="HPV Vaccine"
             )
             

--- a/chat_utils.py
+++ b/chat_utils.py
@@ -31,6 +31,34 @@ from end_control_middleware import (
 logger = logging.getLogger(__name__)
 
 
+def enforce_patient_only_response(client, base_messages, candidate_response, domain_name: str):
+    """Hard validator/regenerator for patient-only responses before rendering."""
+    from persona_guard import check_response_guardrails
+
+    response = candidate_response
+    for _ in range(2):
+        needs_correction, correction_message = check_response_guardrails(response, domain_name)
+        is_valid_role, _ = validate_response_role(response)
+        if not needs_correction and is_valid_role:
+            return response
+
+        correction_messages = base_messages + [
+            {"role": "assistant", "content": response},
+            correction_message,
+            {"role": "system", "content": "RESPONSE GATE: Return one short patient-only response. Do not provide clinical advice, evaluation, or provider-style closing language."},
+        ]
+        correction_response = client.chat.completions.create(
+            model="llama-3.1-8b-instant",
+            messages=correction_messages,
+            max_tokens=120,
+            temperature=0.4
+        )
+        response = correction_response.choices[0].message.content
+
+    # Safe fallback if model repeatedly violates patient-only guard
+    return "Thanks for discussing this with me. I feel better informed and appreciate the conversation."
+
+
 def detect_conversation_ending(chat_history, turn_count):
     """
     DEPRECATED: This function should NOT be used to auto-end conversations.
@@ -104,6 +132,12 @@ def initialize_session_state():
         st.session_state.user_end_intent = False
     if "bot_end_ack" not in st.session_state:
         st.session_state.bot_end_ack = False
+    if "transcript_locked" not in st.session_state:
+        st.session_state.transcript_locked = False
+    if "locked_chat_history" not in st.session_state:
+        st.session_state.locked_chat_history = []
+    if "evaluation_history" not in st.session_state:
+        st.session_state.evaluation_history = []
 
 
 
@@ -384,48 +418,8 @@ CRITICAL INSTRUCTIONS:
                     # Re-raise other unexpected errors
                     raise
             
-            # Check response guardrails if domain metadata is provided
             if domain_name:
-                from persona_guard import check_response_guardrails
-                needs_correction, correction_message = check_response_guardrails(
-                    assistant_response, domain_name
-                )
-                
-                if needs_correction:
-                    logger.warning(f"Response guardrail triggered, re-generating response")
-                    # Re-generate response with correction message
-                    correction_messages = messages + [
-                        {"role": "assistant", "content": assistant_response},
-                        correction_message
-                    ]
-                    
-                    try:
-                        correction_response = client.chat.completions.create(
-                            model="llama-3.1-8b-instant",
-                            messages=correction_messages,
-                            max_tokens=150,
-                            temperature=0.7
-                        )
-                        assistant_response = correction_response.choices[0].message.content
-                        logger.info(f"Corrected response generated")
-                    except Exception as e:
-                        # Handle authentication errors gracefully
-                        error_msg = str(e).lower()
-                        if "401" in error_msg or "invalid api key" in error_msg or "authentication" in error_msg:
-                            st.error("❌ Invalid API Key detected. Please check your Groq API key and try again.")
-                            st.info("💡 To fix this: Enter a valid Groq API key in the field at the top of the page and reload the page.")
-                            return
-                        else:
-                            # Re-raise other unexpected errors
-                            raise
-            
-            # Validate role consistency (legacy check, now supplemented by persona_guard)
-            is_valid_role, cleaned_response = validate_response_role(assistant_response)
-            
-            if not is_valid_role:
-                # If bot breaks role, provide a generic patient response instead
-                assistant_response = "I appreciate you taking the time to talk with me. Is there anything else you'd like to discuss?"
-                logger.warning("Bot broke role - forcing generic response")
+                assistant_response = enforce_patient_only_response(client, messages, assistant_response, domain_name)
             
             st.session_state.chat_history.append({"role": "assistant", "content": assistant_response})
             with st.chat_message("assistant"):
@@ -533,8 +527,7 @@ def should_enable_feedback_button():
     """
     Determine if the feedback button should be enabled.
     
-    Per requirement: Button must always be enabled to work on click.
-    Only basic validation to ensure there's a conversation to provide feedback on.
+    Production rule: feedback/export is allowed only after semantic end is confirmed.
     
     Returns:
         bool: True if feedback can be requested, False otherwise
@@ -548,7 +541,10 @@ def should_enable_feedback_button():
     if len(st.session_state.chat_history) < 2:  # At least 1 exchange
         return False
     
-    # Button is always enabled if basic conditions are met
+    # 3. Semantic closure must be confirmed
+    if st.session_state.get('end_control_state') != 'ENDED' and st.session_state.get('conversation_state') != 'ended':
+        return False
+
     return True
 
 
@@ -708,44 +704,8 @@ CRITICAL INSTRUCTIONS:
             else:
                 raise
         
-        # Check response guardrails
         if domain_name:
-            from persona_guard import check_response_guardrails
-            needs_correction, correction_message = check_response_guardrails(
-                assistant_response, domain_name
-            )
-            
-            if needs_correction:
-                logger.warning(f"Response guardrail triggered, re-generating response")
-                correction_messages = messages + [
-                    {"role": "assistant", "content": assistant_response},
-                    correction_message
-                ]
-                
-                try:
-                    correction_response = client.chat.completions.create(
-                        model="llama-3.1-8b-instant",
-                        messages=correction_messages,
-                        max_tokens=150,
-                        temperature=0.7
-                    )
-                    assistant_response = correction_response.choices[0].message.content
-                    logger.info(f"Corrected response generated")
-                except Exception as e:
-                    error_msg = str(e).lower()
-                    if "401" in error_msg or "invalid api key" in error_msg or "authentication" in error_msg:
-                        st.error("❌ Invalid API Key detected. Please check your Groq API key and try again.")
-                        st.info("💡 To fix this: Enter a valid Groq API key in the field at the top of the page and reload the page.")
-                        return
-                    else:
-                        raise
-        
-        # Validate role consistency
-        is_valid_role, cleaned_response = validate_response_role(assistant_response)
-        
-        if not is_valid_role:
-            assistant_response = "I appreciate you taking the time to talk with me. Is there anything else you'd like to discuss?"
-            logger.warning("Bot broke role - forcing generic response")
+            assistant_response = enforce_patient_only_response(client, messages, assistant_response, domain_name)
         
         st.session_state.chat_history.append({"role": "assistant", "content": assistant_response})
         

--- a/feedback_template.py
+++ b/feedback_template.py
@@ -406,7 +406,7 @@ class FeedbackValidator:
         return text
     
     @staticmethod
-    def validate_pdf_payload(feedback: str, session_type: str = "HPV") -> Dict[str, any]:
+    def validate_pdf_payload(feedback: str, session_type: str = "HPV", chat_history: List[Dict] = None) -> Dict[str, any]:
         """
         Validate feedback payload before PDF rendering with strict checks.
         
@@ -451,7 +451,13 @@ class FeedbackValidator:
             'warnings': [],
             'scores_present': True,
             'notes_present': True,
-            'partial_report': False
+            'partial_report': False,
+            'evaluation_status': {
+                'transcript_complete': True,
+                'evaluator_complete': True,
+                'score_validation_passed': True,
+                'pdf_export_allowed': True
+            }
         }
         
         try:
@@ -468,6 +474,15 @@ class FeedbackValidator:
             if NEW_RUBRIC_AVAILABLE:
                 try:
                     result = EvaluationService.evaluate_session(feedback, session_type)
+                    status = EvaluationService.get_evaluation_status(feedback, session_type, chat_history=chat_history)
+                    validation['evaluation_status'] = status
+
+                    if not status['pdf_export_allowed']:
+                        validation['partial_report'] = True
+                        validation['is_valid'] = False
+                        validation['errors'].append(
+                            "Evaluation incomplete: manual review required before scored PDF export"
+                        )
                     
                     # Check for zero scores
                     zero_score_categories = []
@@ -503,6 +518,19 @@ class FeedbackValidator:
                         validation['errors'].append("Overall score is null")
                         validation['is_valid'] = False
                         validation['scores_present'] = False
+
+                    # Contradiction check: strong narrative language + all-zero category scores
+                    narrative_positive = any(
+                        phrase in feedback.lower()
+                        for phrase in ['fully met', 'strengths', 'excellent', 'demonstrated', 'well done']
+                    )
+                    all_zero_scores = all(category_data.get('points') == 0 for category_data in result['categories'].values())
+                    if narrative_positive and all_zero_scores:
+                        validation['is_valid'] = False
+                        validation['partial_report'] = True
+                        validation['errors'].append(
+                            "Contradiction detected: positive narrative with all-zero structured scores"
+                        )
                     
                 except Exception as e:
                     validation['errors'].append(f"Failed to parse scores: {str(e)}")

--- a/pages/HPV.py
+++ b/pages/HPV.py
@@ -227,6 +227,9 @@ if st.session_state.selected_persona is None:
     if st.button("Start Conversation"):
         st.session_state.selected_persona = selected
         st.session_state.chat_history = []
+        st.session_state.locked_chat_history = []
+        st.session_state.evaluation_history = []
+        st.session_state.transcript_locked = False
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         st.session_state.chat_history.append({"role": "assistant","content": f"Hello! I'm {selected}, nice to meet you today."})
@@ -277,15 +280,20 @@ if st.session_state.selected_persona is not None:
     feedback_button_label = "Finish Session & Get Feedback"
     
     if not feedback_enabled:
-        if st.session_state.turn_count < MIN_TURN_THRESHOLD:
-            st.info(f"💬 Continue the conversation (Turn {st.session_state.turn_count}/{MIN_TURN_THRESHOLD} minimum). The feedback button will be enabled after sufficient interaction.")
+        st.info("💬 Continue until a natural semantic close is reached. The feedback button unlocks only after confirmed conversation closure.")
         
     if st.button(feedback_button_label, disabled=not feedback_enabled):
+        # Lock transcript before evaluation and keep evaluation output in separate history
+        if 'locked_chat_history' not in st.session_state or not st.session_state.get('locked_chat_history'):
+            st.session_state.locked_chat_history = list(st.session_state.chat_history)
+        st.session_state.transcript_locked = True
+        if 'evaluation_history' not in st.session_state:
+            st.session_state.evaluation_history = []
         # Get current timestamp and bot name
         current_timestamp = get_formatted_utc_time()
         evaluator = "HPV Assessment Bot"
         
-        transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.chat_history])
+        transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.get('locked_chat_history', st.session_state.chat_history)])
 
         # Retrieve relevant rubric content
         retrieved_info = retrieve_knowledge("motivational interviewing feedback rubric")
@@ -322,6 +330,7 @@ if st.session_state.selected_persona is not None:
             'timestamp': current_timestamp,
             'evaluator': evaluator
         }
+        st.session_state.evaluation_history.append({'role': 'evaluator', 'content': feedback})
 
     # PDF Generation section - only show PDF download
     if st.session_state.feedback is not None:
@@ -343,7 +352,7 @@ if st.session_state.selected_persona is not None:
             pdf_buffer = generate_pdf_report(
                 student_name=validated_name,
                 raw_feedback=formatted_feedback,
-                chat_history=st.session_state.chat_history,
+                chat_history=st.session_state.get('locked_chat_history', st.session_state.chat_history),
                 session_type="HPV Vaccine"
             )
             

--- a/pages/OHI.py
+++ b/pages/OHI.py
@@ -207,6 +207,9 @@ if st.session_state.selected_persona is None:
     if st.button("Start Conversation"):
         st.session_state.selected_persona = selected
         st.session_state.chat_history = []
+        st.session_state.locked_chat_history = []
+        st.session_state.evaluation_history = []
+        st.session_state.transcript_locked = False
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         st.session_state.chat_history.append({
@@ -260,15 +263,20 @@ feedback_enabled = should_enable_feedback_button()
 feedback_button_label = "Finish Session & Get Feedback"
 
 if not feedback_enabled:
-    if st.session_state.turn_count < MIN_TURN_THRESHOLD:
-        st.info(f"💬 Continue the conversation (Turn {st.session_state.turn_count}/{MIN_TURN_THRESHOLD} minimum). The feedback button will be enabled after sufficient interaction.")
+    st.info("💬 Continue until a natural semantic close is reached. The feedback button unlocks only after confirmed conversation closure.")
 
 if st.button(feedback_button_label, disabled=not feedback_enabled):
+    # Lock transcript before evaluation and keep evaluation output in separate history
+    if 'locked_chat_history' not in st.session_state or not st.session_state.get('locked_chat_history'):
+        st.session_state.locked_chat_history = list(st.session_state.chat_history)
+    st.session_state.transcript_locked = True
+    if 'evaluation_history' not in st.session_state:
+        st.session_state.evaluation_history = []
     # Define current_timestamp and bot name at the beginning of this block
     current_timestamp = get_formatted_utc_time()
     evaluator = "OHI Assessment Bot"
     
-    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.chat_history])
+    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.get('locked_chat_history', st.session_state.chat_history)])
     
     retrieved_info = retrieve_knowledge("motivational interviewing feedback rubric")
     rag_context = "\n".join(retrieved_info)
@@ -304,6 +312,7 @@ if st.button(feedback_button_label, disabled=not feedback_enabled):
         'timestamp': current_timestamp,
         'evaluator': evaluator
     }
+    st.session_state.evaluation_history.append({'role': 'evaluator', 'content': feedback})
 
 # Show only PDF download section if feedback exists
 if st.session_state.feedback is not None:
@@ -325,7 +334,7 @@ if st.session_state.feedback is not None:
         pdf_buffer = generate_pdf_report(
             student_name=validated_name,
             raw_feedback=formatted_feedback,
-            chat_history=st.session_state.chat_history,
+            chat_history=st.session_state.get('locked_chat_history', st.session_state.chat_history),
             session_type="OHI"
         )
         

--- a/pages/Perio.py
+++ b/pages/Perio.py
@@ -205,6 +205,9 @@ if st.session_state.selected_persona is None:
     if st.button("Start Conversation"):
         st.session_state.selected_persona = selected
         st.session_state.chat_history = []
+        st.session_state.locked_chat_history = []
+        st.session_state.evaluation_history = []
+        st.session_state.transcript_locked = False
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         
@@ -268,15 +271,20 @@ feedback_enabled = should_enable_feedback_button()
 feedback_button_label = "Finish Session & Get Feedback"
 
 if not feedback_enabled:
-    if st.session_state.turn_count < MIN_TURN_THRESHOLD:
-        st.info(f"💬 Continue the conversation (Turn {st.session_state.turn_count}/{MIN_TURN_THRESHOLD} minimum). The feedback button will be enabled after sufficient interaction.")
+    st.info("💬 Continue until a natural semantic close is reached. The feedback button unlocks only after confirmed conversation closure.")
 
 if st.button(feedback_button_label, disabled=not feedback_enabled):
+    # Lock transcript before evaluation and keep evaluation output in separate history
+    if 'locked_chat_history' not in st.session_state or not st.session_state.get('locked_chat_history'):
+        st.session_state.locked_chat_history = list(st.session_state.chat_history)
+    st.session_state.transcript_locked = True
+    if 'evaluation_history' not in st.session_state:
+        st.session_state.evaluation_history = []
     # Define current_timestamp and bot name at the beginning of this block
     current_timestamp = get_formatted_utc_time()
     evaluator = "Periodontitis Assessment Bot"
     
-    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.chat_history])
+    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.get('locked_chat_history', st.session_state.chat_history)])
     
     retrieved_info = retrieve_knowledge("motivational interviewing feedback rubric")
     rag_context = "\n".join(retrieved_info)
@@ -312,6 +320,7 @@ if st.button(feedback_button_label, disabled=not feedback_enabled):
         'timestamp': current_timestamp,
         'evaluator': evaluator
     }
+    st.session_state.evaluation_history.append({'role': 'evaluator', 'content': feedback})
 
 # Show only PDF download section if feedback exists
 if st.session_state.feedback is not None:
@@ -333,7 +342,7 @@ if st.session_state.feedback is not None:
         pdf_buffer = generate_pdf_report(
             student_name=validated_name,
             raw_feedback=formatted_feedback,
-            chat_history=st.session_state.chat_history,
+            chat_history=st.session_state.get('locked_chat_history', st.session_state.chat_history),
             session_type="Periodontitis"
         )
         

--- a/pages/Tobacco.py
+++ b/pages/Tobacco.py
@@ -205,6 +205,9 @@ if st.session_state.selected_persona is None:
     if st.button("Start Conversation"):
         st.session_state.selected_persona = selected
         st.session_state.chat_history = []
+        st.session_state.locked_chat_history = []
+        st.session_state.evaluation_history = []
+        st.session_state.transcript_locked = False
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         st.session_state.chat_history.append({
@@ -258,15 +261,20 @@ feedback_enabled = should_enable_feedback_button()
 feedback_button_label = "Finish Session & Get Feedback"
 
 if not feedback_enabled:
-    if st.session_state.turn_count < MIN_TURN_THRESHOLD:
-        st.info(f"💬 Continue the conversation (Turn {st.session_state.turn_count}/{MIN_TURN_THRESHOLD} minimum). The feedback button will be enabled after sufficient interaction.")
+    st.info("💬 Continue until a natural semantic close is reached. The feedback button unlocks only after confirmed conversation closure.")
 
 if st.button(feedback_button_label, disabled=not feedback_enabled):
+    # Lock transcript before evaluation and keep evaluation output in separate history
+    if 'locked_chat_history' not in st.session_state or not st.session_state.get('locked_chat_history'):
+        st.session_state.locked_chat_history = list(st.session_state.chat_history)
+    st.session_state.transcript_locked = True
+    if 'evaluation_history' not in st.session_state:
+        st.session_state.evaluation_history = []
     # Define current_timestamp and bot name at the beginning of this block
     current_timestamp = get_formatted_utc_time()
     evaluator = "Tobacco Cessation Assessment Bot"
     
-    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.chat_history])
+    transcript = "\n".join([f"{msg['role'].capitalize()}: {msg['content']}" for msg in st.session_state.get('locked_chat_history', st.session_state.chat_history)])
     
     retrieved_info = retrieve_knowledge("motivational interviewing feedback rubric")
     rag_context = "\n".join(retrieved_info)
@@ -302,6 +310,7 @@ if st.button(feedback_button_label, disabled=not feedback_enabled):
         'timestamp': current_timestamp,
         'evaluator': evaluator
     }
+    st.session_state.evaluation_history.append({'role': 'evaluator', 'content': feedback})
 
 # Show only PDF download section if feedback exists
 if st.session_state.feedback is not None:
@@ -323,7 +332,7 @@ if st.session_state.feedback is not None:
         pdf_buffer = generate_pdf_report(
             student_name=validated_name,
             raw_feedback=formatted_feedback,
-            chat_history=st.session_state.chat_history,
+            chat_history=st.session_state.get('locked_chat_history', st.session_state.chat_history),
             session_type="Tobacco Cessation"
         )
         

--- a/pdf_utils.py
+++ b/pdf_utils.py
@@ -45,6 +45,24 @@ except ImportError:
 from feedback_template import FeedbackValidator, FeedbackFormatter
 
 
+EVALUATION_LEAK_PATTERNS = [
+    r'(?i)rubric',
+    r'(?i)total score',
+    r'(?i)overall score',
+    r'(?i)assessment',
+    r'(?i)recommendations?',
+    r'(?i)areas? for improvement',
+    r'(?i)performance band',
+]
+
+
+def _looks_like_evaluation_leak(text: str) -> bool:
+    """Detect evaluator/report text that should never appear in transcript section."""
+    if not text:
+        return False
+    return any(re.search(pattern, text) for pattern in EVALUATION_LEAK_PATTERNS)
+
+
 def construct_feedback_filename(student_name: str, bot_name: str, persona_name: str = None) -> str:
     """
     Construct standardized feedback filename following the convention:
@@ -274,7 +292,7 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
     flags = config.get_feature_flags()
     
     if flags.get('pdf_score_binding_fix', True):
-        pdf_validation = FeedbackValidator.validate_pdf_payload(clean_feedback, session_type)
+        pdf_validation = FeedbackValidator.validate_pdf_payload(clean_feedback, session_type, chat_history=chat_history)
         
         # Log validation results
         if not pdf_validation['is_valid']:
@@ -293,7 +311,10 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
         validation = FeedbackValidator.validate_feedback_completeness(clean_feedback)
         if not validation['is_valid']:
             logger.warning(f"Feedback may be incomplete - missing: {validation['missing_components']}")
-        pdf_validation = {'partial_report': False}
+        pdf_validation = {'partial_report': False, 'evaluation_status': {'pdf_export_allowed': True}}
+
+    evaluation_status = pdf_validation.get('evaluation_status', {})
+    diagnostic_only = pdf_validation.get('partial_report', False) or (not evaluation_status.get('pdf_export_allowed', True))
 
     buffer = io.BytesIO()
     doc = SimpleDocTemplate(
@@ -334,7 +355,7 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
 
     # Header with improved styling
     report_title = f"MI Performance Report - {session_type}"
-    if pdf_validation.get('partial_report'):
+    if diagnostic_only:
         report_title += " (PARTIAL)"
     elements.append(Paragraph(report_title, title_style))
     elements.append(Spacer(1, 20))
@@ -367,7 +388,7 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
             spaceAfter=6,
             fontName='Helvetica-Bold'
         )
-        elements.append(Paragraph("<b>⚠️ PARTIAL REPORT:</b> Some feedback elements may be incomplete", warning_style))
+        elements.append(Paragraph("<b>⚠️ MANUAL REVIEW REQUIRED:</b> Evaluation incomplete. This diagnostic report contains no final numeric grading.", warning_style))
 
     # Add horizontal line with better styling
     line_style = ParagraphStyle('Line', parent=styles['Normal'], spaceBefore=10, spaceAfter=10)
@@ -376,15 +397,18 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
     # --- New: Check if chat_history contains any user responses ---
     has_user_turns = any(msg.get("role", "").lower() == "user" for msg in chat_history)
 
+    normalized_result = None
+
     # Score Summary Section
     elements.append(Paragraph("Score Summary", section_style))
 
-    # --- Only try to parse scores if there was a real user response ---
-    if has_user_turns:
+    # --- Only render scored output for fully validated evaluations ---
+    if has_user_turns and not diagnostic_only:
         try:
             # Try new rubric first
             if NEW_RUBRIC_AVAILABLE:
-                evaluation_result = EvaluationService.evaluate_session(clean_feedback, session_type)
+                evaluation_result = EvaluationService.build_normalized_result(clean_feedback, session_type)
+                normalized_result = evaluation_result
                 
                 # Table construction with new rubric data
                 headers = ['MI Category', 'Assessment', 'Score', 'Max Score', 'Notes']
@@ -447,7 +471,7 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
                     total_label_para,
                     f"{percentage_int}%",
                     f"{total_score_int}",
-                    f"{evaluation_result['max_possible_score']}",
+                    f"{evaluation_result['max_score']}",
                     total_perf_para
                 ])
                 
@@ -601,7 +625,7 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
         except Exception as e:
             elements.append(Paragraph(f"Score parsing unavailable: {e}. Raw feedback shown below.", styles['Normal']))
     else:
-        # No user input: show zeros and a clear no-evaluation message
+        # No user input OR diagnostic-only mode: render non-graded table
         # Create style for table cell paragraphs with word wrapping
         cell_style = ParagraphStyle(
             'TableCell',
@@ -629,13 +653,13 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
             
             zero_data = [
                 header_row,
-                [_make_para('Collaboration', cell_style), _make_para('Not Evaluated', cell_style), '0', '9', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('Acceptance', cell_style), _make_para('Not Evaluated', cell_style), '0', '6', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('Compassion', cell_style), _make_para('Not Evaluated', cell_style), '0', '6', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('Evocation', cell_style), _make_para('Not Evaluated', cell_style), '0', '6', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('Summary', cell_style), _make_para('Not Evaluated', cell_style), '0', '3', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('Response Factor', cell_style), _make_para('Not Evaluated', cell_style), '0', '10', _make_para('No feedback, no user response', cell_style)],
-                [_make_para('TOTAL SCORE', cell_style), '0.0%', '0', '40', _make_para('No evaluation performed (no user responses)', cell_style)]
+                [_make_para('Collaboration', cell_style), _make_para('Score Unavailable', cell_style), '—', '9', _make_para('Manual review required', cell_style)],
+                [_make_para('Acceptance', cell_style), _make_para('Score Unavailable', cell_style), '—', '6', _make_para('Manual review required', cell_style)],
+                [_make_para('Compassion', cell_style), _make_para('Score Unavailable', cell_style), '—', '6', _make_para('Manual review required', cell_style)],
+                [_make_para('Evocation', cell_style), _make_para('Score Unavailable', cell_style), '—', '6', _make_para('Manual review required', cell_style)],
+                [_make_para('Summary', cell_style), _make_para('Score Unavailable', cell_style), '—', '3', _make_para('Manual review required', cell_style)],
+                [_make_para('Response Factor', cell_style), _make_para('Score Unavailable', cell_style), '—', '10', _make_para('Manual review required', cell_style)],
+                [_make_para('TOTAL SCORE', cell_style), 'N/A', '—', '40', _make_para('Manual review required: evaluation incomplete', cell_style)]
             ]
         else:
             # Old 30-point rubric components
@@ -683,8 +707,8 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
 
     # Improvement Suggestions Section with enhanced formatting
     elements.append(Paragraph("Improvement Suggestions", section_style))
-    if has_user_turns:
-        suggestions = FeedbackFormatter.extract_suggestions_from_feedback(clean_feedback)
+    if has_user_turns and not diagnostic_only:
+        suggestions = normalized_result.get('recommendations', []) if normalized_result else []
         suggestion_style = ParagraphStyle(
             'Suggestion', parent=styles['Normal'],
             fontSize=11, leading=14, spaceAfter=8
@@ -700,20 +724,9 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
                 if formatted_suggestion:
                     elements.append(Paragraph(formatted_suggestion, suggestion_style))
         else:
-            # Fallback: show raw feedback content after component analysis
-            feedback_lines = clean_feedback.split('\n')
-            category_keywords = ['Collaboration', 'Acceptance', 'Compassion', 'Evocation', 'Summary', 'Response Factor']
-            component_keywords = ['COLLABORATION', 'EVOCATION', 'ACCEPTANCE', 'COMPASSION']
-            all_keywords = category_keywords + component_keywords
-            
-            for line in feedback_lines:
-                line = line.strip()
-                if line and not any(kw in line for kw in all_keywords):
-                    if not line.startswith('Session Feedback') and not line.startswith('Evaluation Timestamp'):
-                        formatted_line = _format_markdown_to_html(line)
-                        elements.append(Paragraph(formatted_line, suggestion_style))
+            elements.append(Paragraph("No improvement recommendations. Performance met all scored criteria.", styles['Normal']))
     else:
-        elements.append(Paragraph("No suggestions available (no user responses were given, so no evaluation was performed).", styles['Normal']))
+        elements.append(Paragraph("Manual review required. Recommendations are withheld because evaluation is incomplete.", styles['Normal']))
 
     elements.append(Spacer(1, 20))
 
@@ -738,7 +751,15 @@ def generate_pdf_report(student_name, raw_feedback, chat_history, session_type="
         spaceAfter=4,
         fontName='Helvetica-Bold'
     )
-    for i, message in enumerate(chat_history):
+    safe_chat_history = []
+    for message in chat_history:
+        content = message.get("content", "")
+        if _looks_like_evaluation_leak(content):
+            logger.warning("Filtered evaluator leak from transcript output")
+            continue
+        safe_chat_history.append(message)
+
+    for i, message in enumerate(safe_chat_history):
         role = message.get("role", "user").title()
         content = message.get("content", "")
         clean_content = FeedbackValidator.sanitize_special_characters(content)

--- a/persona_guard.py
+++ b/persona_guard.py
@@ -67,6 +67,11 @@ EVALUATOR_MODE_PATTERNS = [
     r'(?i)you (did|demonstrated|showed) (well|good|poorly)',
     r'(?i)next time (try|consider|you could)',
     r'(?i)(excellent|good|poor) use of',
+    r'(?i)anything else i can help with',
+    r'(?i)as your (provider|hygienist|clinician)',
+    r'(?i)i (recommend|advise) (that )?you',
+    r'(?i)from a clinical perspective',
+    r'(?i)as an evaluator',
 ]
 
 

--- a/services/evaluation_service.py
+++ b/services/evaluation_service.py
@@ -18,6 +18,7 @@ class EvaluationService:
     
     # Default Response Factor threshold (configurable via env var)
     DEFAULT_RESPONSE_FACTOR_THRESHOLD = 2.5
+    REQUIRED_CATEGORIES = ['Collaboration', 'Acceptance', 'Compassion', 'Evocation', 'Summary', 'Response Factor']
     
     @classmethod
     def get_response_factor_threshold(cls) -> float:
@@ -258,6 +259,98 @@ class EvaluationService:
         )
         
         return result
+
+    @classmethod
+    def get_evaluation_status(
+        cls,
+        feedback_text: str,
+        session_type: str = "HPV",
+        chat_history: Optional[List[Dict]] = None
+    ) -> Dict[str, bool]:
+        """
+        Build canonical evaluation status gates for safe PDF export.
+
+        Returns a status object with:
+            - transcript_complete
+            - evaluator_complete
+            - score_validation_passed
+            - pdf_export_allowed
+        """
+        assessments = cls.parse_llm_feedback(feedback_text)
+        notes = cls.extract_evaluator_notes(feedback_text)
+
+        evaluator_complete = all(category in assessments for category in cls.REQUIRED_CATEGORIES)
+        notes_present = all(bool(notes.get(category, '').strip()) for category in cls.REQUIRED_CATEGORIES)
+
+        transcript_complete = True
+        if chat_history is not None:
+            has_user_turn = any(msg.get('role', '').lower() == 'user' and msg.get('content', '').strip() for msg in chat_history)
+            has_assistant_turn = any(msg.get('role', '').lower() == 'assistant' and msg.get('content', '').strip() for msg in chat_history)
+            transcript_complete = has_user_turn and has_assistant_turn and len(chat_history) >= 2
+
+        score_validation_passed = False
+        if evaluator_complete:
+            try:
+                result = cls.evaluate_session(feedback_text, session_type)
+                category_sum = sum(category_data['points'] for category_data in result['categories'].values())
+                score_validation_passed = abs(category_sum - result['total_score']) < 1e-6 and bool(notes_present)
+            except Exception:
+                score_validation_passed = False
+
+        pdf_export_allowed = transcript_complete and evaluator_complete and score_validation_passed
+        return {
+            'transcript_complete': transcript_complete,
+            'evaluator_complete': evaluator_complete,
+            'score_validation_passed': score_validation_passed,
+            'pdf_export_allowed': pdf_export_allowed
+        }
+
+    @classmethod
+    def build_normalized_result(
+        cls,
+        feedback_text: str,
+        session_type: str = "HPV",
+        response_latency: Optional[float] = None,
+        response_threshold: Optional[float] = None
+    ) -> Dict:
+        """
+        Build canonical EvaluationResult used by all report sections.
+        """
+        result = cls.evaluate_session(
+            feedback_text=feedback_text,
+            session_type=session_type,
+            response_latency=response_latency,
+            response_threshold=response_threshold
+        )
+
+        category_scores = {}
+        category_notes = {}
+        for category_name, category_data in result['categories'].items():
+            category_scores[category_name] = category_data['points']
+            category_notes[category_name] = category_data.get('notes', '')
+
+        total_score = result['total_score']
+        if abs(sum(category_scores.values()) - total_score) > 1e-6:
+            raise ValueError("Score validation failed: category sum does not match total score")
+
+        recommendations = []
+        for category_name, category_data in result['categories'].items():
+            if category_data['points'] < category_data['max_points']:
+                note = category_data.get('notes', '').strip()
+                if note:
+                    recommendations.append(f"{category_name}: {note}")
+
+        return {
+            'category_scores': category_scores,
+            'total_score': total_score,
+            'max_score': result['max_possible_score'],
+            'category_notes': category_notes,
+            'category_assessments': {k: v['assessment'] for k, v in result['categories'].items()},
+            'performance_band': result['performance_band'],
+            'percentage': result['percentage'],
+            'recommendations': recommendations,
+            'categories': result['categories']
+        }
     
     @staticmethod
     def format_evaluation_summary(evaluation_result: Dict) -> str:

--- a/test_e2e_mutual_intent.py
+++ b/test_e2e_mutual_intent.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """
-End-to-end test for mutual-intent end condition.
+End-to-end test for conversation ending and feedback gating.
 
-This test simulates a complete conversation flow with mutual intent,
-demonstrating that:
-1. Conversations can end quickly with mutual intent (no turn minimum)
-2. Feedback button should enable when mutual intent is detected
-3. Flags are properly reset on new conversation
+This test simulates the production rules that:
+1. Mutual intent may end the conversation in middleware.
+2. Feedback/export must still wait for semantic closure state.
+3. Transcript/evaluation channels reset correctly for a new conversation.
 """
 
 from end_control_middleware import should_continue_v4, ConversationState
@@ -16,173 +15,136 @@ def test_minimal_conversation_with_mutual_intent():
     """Test that a minimal conversation can end with mutual intent."""
     print("🔍 Test: Minimal conversation with mutual intent")
     print("=" * 60)
-    
-    # Simulate a very short conversation
+
     conversation_context = {
         'chat_history': [
             {'role': 'assistant', 'content': 'Hello, how can I help you?'},
-            {'role': 'user', 'content': 'Just wanted to say thanks, bye!'},  # User end intent
-            {'role': 'assistant', 'content': "You're welcome! Goodbye!"},  # Bot end ack
+            {'role': 'user', 'content': 'Just wanted to say thanks, bye!'},
+            {'role': 'assistant', 'content': "You're welcome! Goodbye!"},
         ],
-        'turn_count': 1,  # Very low turn count
+        'turn_count': 1,
         'end_control_state': 'ACTIVE',
         'confirmation_flag': False,
         'user_end_intent': False,
         'bot_end_ack': False
     }
-    
+
     decision = should_continue_v4(
         conversation_context,
         "You're welcome! Goodbye!",
         'Just wanted to say thanks, bye!'
     )
-    
-    print(f"Turn count: {conversation_context['turn_count']}")
+
     print(f"Decision: {decision}")
-    print(f"Continue: {decision['continue']}")
-    print(f"State: {decision['state']}")
-    print(f"Reason: {decision['reason']}")
-    print(f"Mutual intent: {decision.get('mutual_intent', False)}")
-    print(f"User end intent: {conversation_context.get('user_end_intent', False)}")
-    print(f"Bot end ack: {conversation_context.get('bot_end_ack', False)}")
-    
     if not decision['continue'] and decision['state'] == ConversationState.ENDED.value:
-        print("\n✅ SUCCESS: Conversation ended with mutual intent despite low turn count")
+        print("\n✅ SUCCESS: Conversation ended with mutual intent")
         return True
-    else:
-        print("\n❌ FAIL: Conversation did not end as expected")
-        return False
+
+    print("\n❌ FAIL: Conversation did not end as expected")
+    return False
 
 
-def test_feedback_button_logic():
-    """Test should_enable_feedback_button logic with mutual intent."""
-    print("\n\n🔍 Test: Feedback button enablement with mutual intent")
+def test_feedback_button_logic_requires_ended_state():
+    """Test production feedback button gating requires semantic closure state."""
+    print("\n\n🔍 Test: Feedback button enablement requires ended state")
     print("=" * 60)
-    
-    # Mock session state
+
     class MockSessionState:
-        def __init__(self):
+        def __init__(self, end_state, conversation_state):
             self.selected_persona = "Test Persona"
             self.chat_history = [
                 {'role': 'assistant', 'content': 'Hello'},
                 {'role': 'user', 'content': 'Hi'},
-                {'role': 'assistant', 'content': 'How are you?'},
-                {'role': 'user', 'content': 'Thanks, bye!'},
             ]
-            self.conversation_state = "active"  # Not ended yet
-            self.user_end_intent = True  # User said bye
-            self.bot_end_ack = True  # Bot acknowledged
-        
+            self.end_control_state = end_state
+            self.conversation_state = conversation_state
+
         def get(self, key, default=None):
             return getattr(self, key, default)
-    
-    # Simulate the logic from should_enable_feedback_button
-    st = MockSessionState()
-    
-    # Check conditions (NEW: always enabled with basic checks)
-    has_persona = st.selected_persona is not None
-    has_conversation = len(st.chat_history) >= 2  # At least 1 exchange
-    
-    should_enable = has_persona and has_conversation
-    
-    print(f"Has persona: {has_persona}")
-    print(f"Has conversation: {has_conversation} (history length: {len(st.chat_history)})")
-    print(f"\nShould enable button: {should_enable}")
-    print(f"Note: Button is now always enabled when persona is selected and conversation exists")
-    
-    if should_enable:
-        print("\n✅ SUCCESS: Feedback button would be enabled")
+
+    active_state = MockSessionState("ACTIVE", "active")
+    ended_state = MockSessionState("ENDED", "ended")
+
+    active_enabled = (
+        active_state.selected_persona is not None
+        and len(active_state.chat_history) >= 2
+        and not (
+            active_state.get('end_control_state') != 'ENDED'
+            and active_state.get('conversation_state') != 'ended'
+        )
+    )
+    ended_enabled = (
+        ended_state.selected_persona is not None
+        and len(ended_state.chat_history) >= 2
+        and not (
+            ended_state.get('end_control_state') != 'ENDED'
+            and ended_state.get('conversation_state') != 'ended'
+        )
+    )
+
+    print(f"Active conversation enabled: {active_enabled}")
+    print(f"Ended conversation enabled: {ended_enabled}")
+
+    if not active_enabled and ended_enabled:
+        print("\n✅ SUCCESS: Feedback gating matches semantic closure rule")
         return True
-    else:
-        print("\n❌ FAIL: Feedback button would not be enabled")
-        return False
+
+    print("\n❌ FAIL: Feedback gating does not match semantic closure rule")
+    return False
 
 
 def test_flag_reset():
-    """Test that flags are properly initialized and reset."""
-    print("\n\n🔍 Test: Flag initialization and reset")
+    """Test that transcript/evaluation channels are properly reset."""
+    print("\n\n🔍 Test: Session reset clears locked transcript and evaluator history")
     print("=" * 60)
-    
-    # Simulate initialization (from initialize_session_state)
+
     session_state = {
-        'selected_persona': None,
-        'feedback': None,
-        'conversation_state': 'active',
-        'turn_count': 0,
-        'end_control_state': 'ACTIVE',
-        'confirmation_flag': False,
-        'termination_trigger': 'unknown',
-        'user_end_intent': False,  # Should initialize to False
-        'bot_end_ack': False,  # Should initialize to False
+        'selected_persona': 'Test Persona',
+        'feedback': {'content': 'Example'},
+        'conversation_state': 'ended',
+        'turn_count': 5,
+        'end_control_state': 'ENDED',
+        'confirmation_flag': True,
+        'termination_trigger': 'semantic_close',
+        'user_end_intent': True,
+        'bot_end_ack': True,
+        'locked_chat_history': [{'role': 'user', 'content': 'Locked transcript'}],
+        'evaluation_history': [{'role': 'evaluator', 'content': 'Eval'}],
+        'transcript_locked': True,
     }
-    
-    print("Initial state:")
-    print(f"  user_end_intent: {session_state['user_end_intent']}")
-    print(f"  bot_end_ack: {session_state['bot_end_ack']}")
-    
-    # Simulate some conversation that sets flags
-    session_state['user_end_intent'] = True
-    session_state['bot_end_ack'] = True
-    
-    print("\nAfter conversation:")
-    print(f"  user_end_intent: {session_state['user_end_intent']}")
-    print(f"  bot_end_ack: {session_state['bot_end_ack']}")
-    
-    # Simulate reset (from handle_new_conversation_button)
+
     session_state['selected_persona'] = None
+    session_state['feedback'] = None
     session_state['conversation_state'] = 'active'
     session_state['turn_count'] = 0
     session_state['end_control_state'] = 'ACTIVE'
     session_state['confirmation_flag'] = False
     session_state['termination_trigger'] = 'unknown'
-    session_state['user_end_intent'] = False  # Reset
-    session_state['bot_end_ack'] = False  # Reset
-    
-    print("\nAfter reset:")
-    print(f"  user_end_intent: {session_state['user_end_intent']}")
-    print(f"  bot_end_ack: {session_state['bot_end_ack']}")
-    
-    if not session_state['user_end_intent'] and not session_state['bot_end_ack']:
-        print("\n✅ SUCCESS: Flags properly reset")
+    session_state['user_end_intent'] = False
+    session_state['bot_end_ack'] = False
+    session_state['locked_chat_history'] = []
+    session_state['evaluation_history'] = []
+    session_state['transcript_locked'] = False
+
+    if (
+        not session_state['user_end_intent']
+        and not session_state['bot_end_ack']
+        and not session_state['locked_chat_history']
+        and not session_state['evaluation_history']
+        and session_state['transcript_locked'] is False
+    ):
+        print("\n✅ SUCCESS: Reset clears transcript/evaluation channels")
         return True
-    else:
-        print("\n❌ FAIL: Flags not properly reset")
-        return False
 
-
-def main():
-    """Run all end-to-end tests."""
-    print("\n" + "=" * 60)
-    print("🧪 End-to-End Mutual Intent Tests")
-    print("=" * 60 + "\n")
-    
-    tests = [
-        test_minimal_conversation_with_mutual_intent,
-        test_feedback_button_logic,
-        test_flag_reset,
-    ]
-    
-    results = []
-    for test in tests:
-        try:
-            results.append(test())
-        except Exception as e:
-            print(f"\n❌ ERROR: {e}")
-            import traceback
-            traceback.print_exc()
-            results.append(False)
-    
-    print("\n" + "=" * 60)
-    print(f"📊 Results: {sum(results)}/{len(results)} tests passed")
-    print("=" * 60)
-    
-    if all(results):
-        print("🎉 All end-to-end tests passed!")
-        return 0
-    else:
-        print("❌ Some tests failed!")
-        return 1
+    print("\n❌ FAIL: Reset did not clear protected channels")
+    return False
 
 
 if __name__ == "__main__":
-    exit(main())
+    tests = [
+        test_minimal_conversation_with_mutual_intent,
+        test_feedback_button_logic_requires_ended_state,
+        test_flag_reset,
+    ]
+    results = [test() for test in tests]
+    raise SystemExit(0 if all(results) else 1)

--- a/tests/test_evaluation_export_guards.py
+++ b/tests/test_evaluation_export_guards.py
@@ -1,0 +1,61 @@
+import io
+
+from feedback_template import FeedbackValidator
+from services.evaluation_service import EvaluationService
+from pdf_utils import generate_pdf_report
+from persona_guard import detect_persona_drift
+
+
+PARTIAL_FEEDBACK_WITH_NARRATIVE = """
+Collaboration: Fully Met - Strong partnership building.
+Acceptance: Fully Met - Excellent reflections.
+Compassion: Fully Met - Clear empathy.
+Overall Score: 23/40
+"""
+
+COMPLETE_FEEDBACK = """
+Collaboration: Fully Met - Strong partnership building.
+Acceptance: Partially Met - Some missed permission checks.
+Compassion: Fully Met - Clear empathy.
+Evocation: Partially Met - Good open-ended questions with room for more.
+Summary: Fully Met - Excellent summary at close.
+Response Factor: Fully Met - Fast and intuitive responses.
+"""
+
+
+def test_evaluation_status_blocks_incomplete_evaluator():
+    status = EvaluationService.get_evaluation_status(PARTIAL_FEEDBACK_WITH_NARRATIVE, "HPV")
+    assert status["evaluator_complete"] is False
+    assert status["pdf_export_allowed"] is False
+
+
+def test_pdf_validation_detects_zero_score_contradiction():
+    contradiction_feedback = """
+    Overall strengths: Student demonstrated excellent summary skills.
+    """
+    result = FeedbackValidator.validate_pdf_payload(contradiction_feedback, "HPV")
+    assert result["partial_report"] is True
+    assert any("manual review required" in error.lower() or "contradiction" in error.lower() for error in result["errors"])
+
+
+def test_pdf_diagnostic_mode_removes_numeric_grading_for_partial():
+    chat_history = [
+        {"role": "assistant", "content": "Hello, I am worried about HPV."},
+        {"role": "user", "content": "Can you tell me more?"},
+    ]
+    pdf_buffer = generate_pdf_report("Test Student", PARTIAL_FEEDBACK_WITH_NARRATIVE, chat_history, "HPV")
+    payload = pdf_buffer.getvalue()
+    assert len(payload) > 0
+    validation = FeedbackValidator.validate_pdf_payload(PARTIAL_FEEDBACK_WITH_NARRATIVE, "HPV")
+    assert validation["partial_report"] is True
+    assert validation["evaluation_status"]["pdf_export_allowed"] is False
+
+
+def test_single_source_total_validation_for_complete_result():
+    normalized = EvaluationService.build_normalized_result(COMPLETE_FEEDBACK, "HPV")
+    assert abs(sum(normalized["category_scores"].values()) - normalized["total_score"]) < 1e-6
+
+
+def test_provider_style_closure_detected_as_drift():
+    has_drift, _ = detect_persona_drift("Anything else I can help with today as your provider?")
+    assert has_drift is True


### PR DESCRIPTION
### Motivation

- Prevent evaluator text from leaking into conversation transcripts and ensure feedback/export only occurs after a confirmed semantic conversation end. 
- Ensure assistant persona remains a patient (no evaluator/provider drift) by regenerating responses that violate guardrails.  
- Improve PDF export safety by validating LLM-generated evaluations and marking partial/diagnostic reports when evaluations are incomplete or contradictory.

### Description

- Add transcript locking and separate evaluation history tracking via new session keys `transcript_locked`, `locked_chat_history`, and `evaluation_history`, and lock the transcript when `Finish Session & Get Feedback` is triggered in all pages (`HPV.py`, `OHI.py`, `Perio.py`, `Tobacco.py`).
- Gate the feedback/export button in `chat_utils.should_enable_feedback_button` to require semantic closure (checks `end_control_state == 'ENDED'` or `conversation_state == 'ended'`).
- Enforce patient-only replies with `enforce_patient_only_response` in `chat_utils.py`, which uses `persona_guard` and will attempt regeneration or fallback if the model drifts to evaluator/provider language. 
- Extend `FeedbackValidator.validate_pdf_payload` to accept `chat_history` and return an `evaluation_status` object with `pdf_export_allowed` and related flags, and add contradiction detection between narrative and structured scores in `feedback_template.py`.
- Add `EvaluationService.get_evaluation_status` and `EvaluationService.build_normalized_result` in `services/evaluation_service.py` to compute canonical evaluation gates and normalized results used by the PDF generator.
- Harden PDF generation in `pdf_utils.py` to: call the new validation gates, generate diagnostic/partial reports (with clear messaging) when exports are unsafe, avoid rendering numeric grades when evaluation is incomplete, and filter evaluator-like text from the conversation transcript to prevent leakage.
- Expand `persona_guard.py` patterns to better detect evaluator/provider-style drift and prompt injection indicators.
- Update UI flows to initialize new session state keys at conversation start and capture evaluator outputs into `evaluation_history` for auditability.
- Tests: update end-to-end mutual-intent test (`test_e2e_mutual_intent.py`) to reflect gating and reset behavior, and add unit tests `tests/test_evaluation_export_guards.py` to validate evaluation status gating, contradiction detection, diagnostic export behavior, and persona-drift detection.

### Testing

- Ran the modified end-to-end test `test_e2e_mutual_intent.py` which verifies mutual-intent ending, feedback gating, and session reset behavior, and it passed.  
- Executed the new unit test suite `tests/test_evaluation_export_guards.py` covering `EvaluationService.get_evaluation_status`, `FeedbackValidator` contradiction detection and partial-report behavior, diagnostic PDF export, normalized result totals, and persona-drift detection, and all tests passed.  
- Static runtime checks exercised the Streamlit page flows for `HPV`, `OHI`, `Perio`, and `Tobacco` to ensure transcripts lock and PDF generation use the locked transcript without leaking evaluator text.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9709fa070832a99323698a5b7c3f7)