### PR TITLE
Fix 7 pilot bugs: evaluation scoring, role switching, greeting detection

### DIFF
--- a/chat_utils.py
+++ b/chat_utils.py
@@ -16,7 +16,7 @@ import streamlit as st
 import logging
 from groq import Groq
 from time_utils import get_formatted_utc_time
-from feedback_template import FeedbackFormatter
+from feedback_template import FeedbackFormatter, EVALUATOR_SYSTEM_PROMPT
 from scoring_utils import validate_student_name
 from pdf_utils import generate_pdf_report
 from end_control_middleware import (
@@ -210,9 +210,9 @@ def generate_and_display_feedback(personas_dict, session_type, student_name, ret
 
     try:
         feedback_response = client.chat.completions.create(
-            model="llama-3.1-8b-instant",
+            model="llama-3.3-70b-versatile",
             messages=[
-                {"role": "system", "content": personas_dict[st.session_state.selected_persona]},
+                {"role": "system", "content": EVALUATOR_SYSTEM_PROMPT},
                 {"role": "user", "content": review_prompt}
             ]
         )
@@ -348,9 +348,10 @@ def handle_chat_input(personas_dict, client, domain_name=None, domain_keywords=N
             if domain_name and domain_keywords:
                 from persona_guard import apply_guardrails
                 needs_intervention, guard_message = apply_guardrails(
-                    user_prompt, domain_name, domain_keywords
+                    user_prompt, domain_name, domain_keywords,
+                    turn_count=st.session_state.get('turn_count', 0)
                 )
-                
+
                 if needs_intervention:
                     logger.warning(f"Guardrail intervention triggered for user message: '{user_prompt[:50]}'")
             
@@ -388,7 +389,21 @@ CRITICAL INSTRUCTIONS:
                 messages.append(guard_message)
             
             messages.extend(st.session_state.chat_history)
-            
+
+            # Mid-conversation role reinforcement: every 4 assistant turns, remind
+            # the model it is the PATIENT to prevent provider-voice drift in long sessions.
+            current_turn = st.session_state.get('turn_count', 0)
+            if current_turn > 0 and current_turn % 4 == 0:
+                messages.append({
+                    "role": "system",
+                    "content": (
+                        "REMINDER: You are the PATIENT, not the provider. "
+                        "Do NOT use provider language like 'You're welcome', "
+                        "'Is there anything else I can do for you', or "
+                        "'It was a pleasure helping you.' Continue responding as the patient."
+                    )
+                })
+
             try:
                 response = client.chat.completions.create(
                     model="llama-3.1-8b-instant",
@@ -548,9 +563,10 @@ def handle_chat_input_with_voice(personas_dict, client, domain_name=None, domain
         if domain_name and domain_keywords:
             from persona_guard import apply_guardrails
             needs_intervention, guard_message = apply_guardrails(
-                user_prompt, domain_name, domain_keywords
+                user_prompt, domain_name, domain_keywords,
+                turn_count=st.session_state.get('turn_count', 0)
             )
-            
+
             if needs_intervention:
                 logger.warning(f"Guardrail intervention triggered for user message: '{user_prompt[:50]}'")
         
@@ -587,7 +603,20 @@ CRITICAL INSTRUCTIONS:
             messages.append(guard_message)
         
         messages.extend(st.session_state.chat_history)
-        
+
+        # Mid-conversation role reinforcement for voice mode path
+        current_turn = st.session_state.get('turn_count', 0)
+        if current_turn > 0 and current_turn % 4 == 0:
+            messages.append({
+                "role": "system",
+                "content": (
+                    "REMINDER: You are the PATIENT, not the provider. "
+                    "Do NOT use provider language like 'You're welcome', "
+                    "'Is there anything else I can do for you', or "
+                    "'It was a pleasure helping you.' Continue responding as the patient."
+                )
+            })
+
         try:
             response = client.chat.completions.create(
                 model="llama-3.1-8b-instant",

--- a/feedback_template.py
+++ b/feedback_template.py
@@ -33,9 +33,31 @@ except ImportError:
     OLD_SCORER_AVAILABLE = False
 
 
+# Dedicated evaluator system prompt — used for the evaluation LLM call only.
+# This replaces the patient persona that was previously (incorrectly) used as
+# the system prompt during evaluation, which caused conflicting instructions.
+EVALUATOR_SYSTEM_PROMPT = """You are an expert Motivational Interviewing (MI) evaluator for dental and healthcare education. Your ONLY role is to assess student MI skills using the provided rubric.
+
+CRITICAL FORMAT RULES:
+- You MUST output EXACTLY 6 category assessment lines.
+- Each line MUST start with ** and follow this EXACT format:
+  **Category Name (X pts): [Assessment Level] - [Your specific feedback with direct conversation quotes]**
+- The 6 categories are: Collaboration, Acceptance, Compassion, Evocation, Summary, Response Factor.
+- Assessment levels MUST be one of: Fully Met, Partially Met, Minimally Met, Not Met
+- You MUST include direct conversation quotes from the student to justify each assessment.
+- Do NOT skip any category. Do NOT add commentary before the first category line.
+- After all 6 categories, provide overall recommendations and a total score.
+
+IMPORTANT GRADING PRINCIPLES:
+- Evaluate MI TECHNIQUE only. Do NOT penalize spelling, grammar, or English proficiency.
+- Focus on whether the student demonstrates MI skills (open questions, reflections, empathy, collaboration) regardless of how the text is written.
+- Spelling errors, grammatical mistakes, and informal language should NOT affect any category scores.
+- Be fair and constructive. Highlight strengths before areas for improvement."""
+
+
 class FeedbackFormatter:
     """Handles standardized feedback formatting for MI assessments."""
-    
+
     @staticmethod
     def format_evaluation_prompt(session_type: str, transcript: str, rag_context: str) -> str:
         """Generate standardized evaluation prompt for both HPV and OHI assessments using updated 40-point rubric with granular scoring."""
@@ -124,6 +146,7 @@ class FeedbackFormatter:
         - Include overall recommendations for continued learning and skill development
         - Maintain a supportive and educational tone throughout your feedback
         - Use granular scoring levels: Fully Met, Partially Met, Minimally Met, or Not Met
+        - **IMPORTANT**: Evaluate MI TECHNIQUE, not language proficiency. Spelling errors, grammatical mistakes, and informal language should NOT affect any category scores. Focus exclusively on MI skills.
 
         Remember: Your feedback should help the student understand both what they did well and how they can improve their MI skills in future conversations. Total possible score is 40 points. **Always include conversation quotes to support your assessment.**
         """

--- a/pages/HPV.py
+++ b/pages/HPV.py
@@ -36,7 +36,7 @@ import faiss
 import numpy as np
 from time_utils import get_formatted_utc_time
 from pdf_utils import generate_pdf_report
-from feedback_template import FeedbackFormatter, FeedbackValidator
+from feedback_template import FeedbackFormatter, FeedbackValidator, EVALUATOR_SYSTEM_PROMPT
 from scoring_utils import validate_student_name
 from persona_texts import (
     HPV_PERSONAS, 
@@ -317,9 +317,9 @@ if st.session_state.selected_persona is not None:
 
             try:
                 feedback_response = client.chat.completions.create(
-                    model="llama-3.1-8b-instant",
+                    model="llama-3.3-70b-versatile",
                     messages=[
-                        {"role": "system", "content": PERSONAS[st.session_state.selected_persona]},
+                        {"role": "system", "content": EVALUATOR_SYSTEM_PROMPT},
                         {"role": "user", "content": review_prompt}
                     ]
                 )

--- a/pages/OHI.py
+++ b/pages/OHI.py
@@ -36,7 +36,7 @@ import faiss
 import numpy as np
 from time_utils import get_formatted_utc_time
 from pdf_utils import generate_pdf_report
-from feedback_template import FeedbackFormatter, FeedbackValidator
+from feedback_template import FeedbackFormatter, FeedbackValidator, EVALUATOR_SYSTEM_PROMPT
 from scoring_utils import validate_student_name
 from persona_texts import (
     OHI_PERSONAS,
@@ -299,9 +299,9 @@ if st.button(feedback_button_label):
 
         try:
             feedback_response = client.chat.completions.create(
-                model="llama-3.1-8b-instant",
+                model="llama-3.3-70b-versatile",
                 messages=[
-                    {"role": "system", "content": PERSONAS[st.session_state.selected_persona]},
+                    {"role": "system", "content": EVALUATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": review_prompt}
                 ]
             )

--- a/pages/Perio.py
+++ b/pages/Perio.py
@@ -36,7 +36,7 @@ import faiss
 import numpy as np
 from time_utils import get_formatted_utc_time
 from pdf_utils import generate_pdf_report
-from feedback_template import FeedbackFormatter, FeedbackValidator
+from feedback_template import FeedbackFormatter, FeedbackValidator, EVALUATOR_SYSTEM_PROMPT
 from scoring_utils import validate_student_name
 from persona_texts import (
     PERIO_PERSONAS,
@@ -307,9 +307,9 @@ if st.button(feedback_button_label):
 
         try:
             feedback_response = client.chat.completions.create(
-                model="llama-3.1-8b-instant",
+                model="llama-3.3-70b-versatile",
                 messages=[
-                    {"role": "system", "content": PERSONAS[st.session_state.selected_persona]},
+                    {"role": "system", "content": EVALUATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": review_prompt}
                 ]
             )

--- a/pages/Tobacco.py
+++ b/pages/Tobacco.py
@@ -36,7 +36,7 @@ import faiss
 import numpy as np
 from time_utils import get_formatted_utc_time
 from pdf_utils import generate_pdf_report
-from feedback_template import FeedbackFormatter, FeedbackValidator
+from feedback_template import FeedbackFormatter, FeedbackValidator, EVALUATOR_SYSTEM_PROMPT
 from scoring_utils import validate_student_name
 from persona_texts import (
     TOBACCO_PERSONAS,
@@ -297,9 +297,9 @@ if st.button(feedback_button_label):
 
         try:
             feedback_response = client.chat.completions.create(
-                model="llama-3.1-8b-instant",
+                model="llama-3.3-70b-versatile",
                 messages=[
-                    {"role": "system", "content": PERSONAS[st.session_state.selected_persona]},
+                    {"role": "system", "content": EVALUATOR_SYSTEM_PROMPT},
                     {"role": "user", "content": review_prompt}
                 ]
             )

--- a/persona_guard.py
+++ b/persona_guard.py
@@ -56,6 +56,7 @@ INJECTION_PATTERNS = [
 
 # Evaluator/feedback mode indicators (persona drift detection)
 EVALUATOR_MODE_PATTERNS = [
+    # Academic/evaluator language
     r'(?i)(feedback|evaluation) report',
     r'(?i)score:?\s*\d+',
     r'(?i)rubric category',
@@ -67,11 +68,21 @@ EVALUATOR_MODE_PATTERNS = [
     r'(?i)you (did|demonstrated|showed) (well|good|poorly)',
     r'(?i)next time (try|consider|you could)',
     r'(?i)(excellent|good|poor) use of',
-    r'(?i)anything else i can help with',
+    r'(?i)as an evaluator',
+    # Provider-voice drift (bot acting as clinician instead of patient)
+    r"(?i)anything else i can (do|help).{0,15}(with|for you)",
     r'(?i)as your (provider|hygienist|clinician)',
     r'(?i)i (recommend|advise) (that )?you',
     r'(?i)from a clinical perspective',
-    r'(?i)as an evaluator',
+    r"(?i)you'?re welcome.{0,20}(pleasure|glad)",
+    r"(?i)i('m| am) (glad|happy) i could help",
+    r"(?i)is there anything else i can (do|help)",
+    r"(?i)before (we|you) (wrap|go|leave|finish)",
+    r"(?i)it was (a |my )?pleasure (helping|talking|discussing)",
+    r"(?i)don'?t hesitate to (ask|reach|come back|contact)",
+    r"(?i)take care of (yourself|yourselves)",
+    r"(?i)have a (good|great|nice) (day|rest of)",
+    r"(?i)getting the vaccine.{0,20}(great|good|smart|wise) (decision|choice)",
 ]
 
 
@@ -96,50 +107,76 @@ def detect_prompt_injection(user_message: str) -> Tuple[bool, Optional[str]]:
     return False, None
 
 
-def detect_off_topic(user_message: str, domain_keywords: List[str], threshold: int = 3) -> bool:
+# Greeting/introduction patterns that should NEVER be flagged as off-topic.
+# Introductions and rapport-building are essential MI skills.
+GREETING_PATTERNS = [
+    r"(?i)\b(hello|hi|hey|good morning|good afternoon|good evening)\b",
+    r"(?i)my name is",
+    r"(?i)nice to meet you",
+    r"(?i)i('m| am| will be) your.{0,20}(hygienist|provider|clinician|dentist|assistant)",
+    r"(?i)how are you",
+    r"(?i)welcome to",
+    r"(?i)thank you for coming",
+    r"(?i)i('ll| will) be (working|helping|seeing|talking)",
+    r"(?i)thanks for (coming|being|meeting|joining)",
+    r"(?i)pleasure to meet",
+]
+
+
+def detect_off_topic(user_message: str, domain_keywords: List[str], threshold: int = 3, turn_count: int = None) -> bool:
     """
     Detect if user message is off-topic (not related to domain).
-    
+
     This uses keyword matching to determine if the message is about the domain topic.
     If the message is short (< 5 words) and contains no domain keywords, it's considered off-topic.
-    
+
     Args:
         user_message: The user's input message
         domain_keywords: List of keywords relevant to the domain
         threshold: Minimum message length (words) to check for off-topic
-        
+        turn_count: Current conversation turn count (first few turns are introductory)
+
     Returns:
         bool: True if message is off-topic
     """
     message_lower = user_message.lower()
     words = message_lower.split()
-    
+
     # Very short messages (greetings, acknowledgments) are not off-topic
     if len(words) < threshold:
         return False
-    
+
+    # Never flag greetings/introductions as off-topic — these are essential MI skills
+    for pattern in GREETING_PATTERNS:
+        if re.search(pattern, message_lower):
+            return False
+
+    # First 3 turns are introductory — skip off-topic check entirely
+    if turn_count is not None and turn_count <= 3:
+        return False
+
     # Check if message contains any domain keywords
     for keyword in domain_keywords:
         if keyword.lower() in message_lower:
             return False
-    
+
     # Check if message is asking about unrelated common topics
     unrelated_topics = [
         'weather', 'politics', 'sports', 'movie', 'music', 'food', 'recipe',
         'travel', 'vacation', 'hobby', 'job', 'work', 'school', 'homework',
         'news', 'celebrity', 'game', 'shopping', 'fashion', 'car', 'house'
     ]
-    
+
     for topic in unrelated_topics:
         if topic in message_lower:
             logger.info(f"Off-topic detected: unrelated topic '{topic}' in message")
             return True
-    
+
     # If message is long but contains no domain keywords, might be off-topic
     # But we're lenient here to avoid false positives
     if len(words) > 10:
         logger.debug(f"Long message without domain keywords, but allowing: '{user_message[:100]}'")
-    
+
     return False
 
 
@@ -274,16 +311,18 @@ REGENERATE your last response in 2-3 sentences or less."""
 def apply_guardrails(
     user_message: str,
     domain_name: str,
-    domain_keywords: List[str]
+    domain_keywords: List[str],
+    turn_count: int = None
 ) -> Tuple[bool, Optional[Dict]]:
     """
     Apply all guardrails to user input and determine if intervention is needed.
-    
+
     Args:
         user_message: The user's input message
         domain_name: Name of the domain (e.g., "HPV vaccination")
         domain_keywords: List of domain-relevant keywords
-        
+        turn_count: Current conversation turn count (passed to off-topic detection)
+
     Returns:
         Tuple of (needs_intervention, guard_message):
             - needs_intervention: True if guardrail triggered
@@ -293,12 +332,12 @@ def apply_guardrails(
     is_injection, _ = detect_prompt_injection(user_message)
     if is_injection:
         return True, create_injection_guard_message(domain_name)
-    
-    # Check for off-topic queries
-    is_off_topic = detect_off_topic(user_message, domain_keywords)
+
+    # Check for off-topic queries (with turn-count awareness)
+    is_off_topic = detect_off_topic(user_message, domain_keywords, turn_count=turn_count)
     if is_off_topic:
         return True, create_off_topic_guard_message(domain_name)
-    
+
     # No intervention needed
     return False, None
 

--- a/services/evaluation_service.py
+++ b/services/evaluation_service.py
@@ -7,8 +7,11 @@ Handles parsing of LLM feedback, context determination, and score calculation.
 
 import os
 import re
+import logging
 from typing import Dict, List, Optional, Tuple
 from rubric.mi_rubric import MIRubric, MIEvaluator, CategoryAssessment, RubricContext
+
+logger = logging.getLogger(__name__)
 
 
 class EvaluationService:
@@ -56,7 +59,7 @@ class EvaluationService:
         assessments = {}
         lines = feedback_text.split('\n')
         
-        # Regex patterns to match category lines
+        # Regex patterns to match category lines (ordered most-specific to broadest)
         patterns = [
             # Pattern with dash: "Collaboration: Fully Met - ..." or with bold markdown
             r'^\*{0,2}(?:\d+\.\s*)?(?:\*{0,2})?(Collaboration|Acceptance|Compassion|Evocation|Summary|Response Factor)(?:\s*\([\d.]+\s*pts?\))?\s*:?\s*(?:\*{0,2})?\s*(Fully Met|Partially Met|Minimally Met|Not Met|Meets Criteria|Needs Improvement)(?:\s*\([\d/]+\))?(?:\*{0,2})?\s*[-–—]',
@@ -64,6 +67,8 @@ class EvaluationService:
             r'^\*{0,2}(?:\d+\.\s*)?(?:\*{0,2})?(Collaboration|Acceptance|Compassion|Evocation|Summary|Response Factor)(?:\s*\([\d.]+\s*pts?\))?\s*:?\s*(?:\*{0,2})?\s*(Fully Met|Partially Met|Minimally Met|Not Met|Meets Criteria|Needs Improvement)(?:\s*\([\d/]+\))?(?:\*{0,2})?\s*$',
             # Pattern with brackets: "Collaboration: [Fully Met] - ..."
             r'^\*{0,2}(?:\d+\.\s*)?(?:\*{0,2})?(Collaboration|Acceptance|Compassion|Evocation|Summary|Response Factor)(?:\s*\([\d.]+\s*pts?\))?\s*:?\s*\[\s*(Fully Met|Partially Met|Minimally Met|Not Met|Meets Criteria|Needs Improvement)(?:\s*[\d/]+)?\s*\]',
+            # Fallback: loose match — category name anywhere on line + assessment level
+            r'(?:\*{0,2})?(Collaboration|Acceptance|Compassion|Evocation|Summary|Response Factor)\b.*?\b(Fully Met|Partially Met|Minimally Met|Not Met|Meets Criteria|Needs Improvement)\b',
         ]
         
         for line in lines:
@@ -97,8 +102,40 @@ class EvaluationService:
                     assessments[category_normalized] = assessment
                     break
         
+        if len(assessments) < 6:
+            logger.warning(
+                "Incomplete parse: found %d/6 categories. Missing: %s",
+                len(assessments),
+                [c for c in ['Collaboration', 'Acceptance', 'Compassion', 'Evocation', 'Summary', 'Response Factor']
+                 if c.title() not in assessments and c not in assessments]
+            )
+
         return assessments
-    
+
+    @staticmethod
+    def extract_narrative_score(feedback_text: str) -> Optional[float]:
+        """
+        Fallback: extract a total score from narrative text when structured parsing fails.
+        Looks for patterns like 'Total score: 33/40', 'Score: 26/40', '33 out of 40', etc.
+
+        Returns:
+            The extracted score as a float, or None if not found.
+        """
+        patterns = [
+            r'(?i)total\s*(?:score|points?)\s*:?\s*(\d+(?:\.\d+)?)\s*/\s*40',
+            r'(?i)score\s*(?:of\s*)?:?\s*(\d+(?:\.\d+)?)\s*/\s*40',
+            r'(?i)(\d+(?:\.\d+)?)\s*(?:out of|/)\s*40\s*(?:points?|pts?)',
+            r'(?i)(\d+(?:\.\d+)?)\s*/\s*40',
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, feedback_text)
+            if match:
+                score = float(match.group(1))
+                if 0 <= score <= 40:
+                    logger.info("Extracted narrative score: %.1f/40", score)
+                    return score
+        return None
+
     @staticmethod
     def determine_context(session_type: str) -> RubricContext:
         """
@@ -177,18 +214,25 @@ class EvaluationService:
     def generate_default_notes(category: str, assessment: CategoryAssessment, context: RubricContext) -> str:
         """
         Generate constructive default notes when LLM feedback lacks specific details.
-        
+
         Args:
             category: Category name
-            assessment: CategoryAssessment (MEETS_CRITERIA or NEEDS_IMPROVEMENT)
-            context: RubricContext (HPV or OHI)
-            
+            assessment: CategoryAssessment enum value
+            context: RubricContext (HPV, OHI, TOBACCO, PERIO)
+
         Returns:
             Constructive feedback note
         """
-        context_text = "HPV vaccination" if context == RubricContext.HPV else "oral health"
-        
-        if assessment == CategoryAssessment.MEETS_CRITERIA:
+        context_map = {
+            RubricContext.HPV: "HPV vaccination",
+            RubricContext.OHI: "oral health",
+            RubricContext.TOBACCO: "tobacco cessation",
+            RubricContext.PERIO: "periodontitis and gum health",
+        }
+        context_text = context_map.get(context, "the health topic")
+
+        # Positive notes for FULLY MET and legacy MEETS_CRITERIA
+        if assessment in [CategoryAssessment.MEETS_CRITERIA, CategoryAssessment.FULLY_MET]:
             # Positive constructive feedback for meeting criteria
             positive_notes = {
                 'Collaboration': f'Demonstrated effective partnership and collaboration skills in discussing {context_text}.',
@@ -245,6 +289,15 @@ class EvaluationService:
             if category_name in assessments and (category_name not in notes or not notes[category_name]):
                 assessment = assessments[category_name]
                 notes[category_name] = cls.generate_default_notes(category_name, assessment, context)
+
+        # Fix Bug 7: If a category is Fully Met but the LLM-generated note contains
+        # improvement language (e.g., "Consider...", "Try to..."), replace with praise.
+        improvement_words = ['consider', 'try to', 'work on', 'practice', 'focus on', 'could improve']
+        for category_name in assessments:
+            if assessments[category_name] in [CategoryAssessment.FULLY_MET, CategoryAssessment.MEETS_CRITERIA]:
+                note = notes.get(category_name, '')
+                if note and any(word in note.lower() for word in improvement_words):
+                    notes[category_name] = cls.generate_default_notes(category_name, assessments[category_name], context)
         
         # Get threshold
         threshold = response_threshold or cls.get_response_factor_threshold()


### PR DESCRIPTION
Bugs fixed from HPV pilot run with 37 students:

1. (Critical) Rubric table shows 0/40 while narrative has correct scores: Added 4th fallback regex pattern, narrative score extractor, and incomplete-parse logging in evaluation_service.py

2. (Critical) Patient persona used as evaluator system prompt: Created dedicated EVALUATOR_SYSTEM_PROMPT in feedback_template.py; replaced patient persona in all 5 evaluation LLM calls

3. (High) Bot switches from patient to provider role mid-conversation: Added 9 provider-voice detection patterns to persona_guard.py and mid-conversation role reinforcement every 4 turns in chat_utils.py

4. (High) Student greetings falsely flagged as off-topic: Added GREETING_PATTERNS whitelist and turn-count bypass for first 3 turns in persona_guard.py

5. (Medium) 8B model too small for structured evaluation: Switched evaluation calls to llama-3.3-70b-versatile while keeping llama-3.1-8b-instant for conversation

6. (Medium) Non-native English speakers penalized unfairly: Added ESL accommodation instructions to both evaluator system prompt and evaluation prompt template

7. (Low) Perfect scores show improvement suggestions: Fixed generate_default_notes() to handle FULLY_MET assessment and filter improvement language from perfect-score category notes