### PR TITLE
Fix OHI pilot bugs: turn instruction, token limits, persona hardening

### DIFF
--- a/chat_utils.py
+++ b/chat_utils.py
@@ -28,6 +28,20 @@ from end_control_middleware import (
 logger = logging.getLogger(__name__)
 
 
+def sanitize_bot_response(response: str) -> str:
+    """Strip conversation-ending tokens and artifacts from bot output.
+
+    The bot sometimes generates <<END>>, <<>>, <>, or partial end markers
+    that should never be displayed to the student.
+    """
+    import re
+    # Remove <<END>>, <<>>, <>, and variations (with optional whitespace)
+    cleaned = re.sub(r'<{1,2}\s*(?:END)?\s*>{1,2}', '', response)
+    # Remove trailing whitespace left after stripping
+    cleaned = cleaned.strip()
+    return cleaned
+
+
 def enforce_patient_only_response(client, base_messages, candidate_response, domain_name: str):
     """Hard validator/regenerator for patient-only responses before rendering."""
     from persona_guard import check_response_guardrails
@@ -47,7 +61,7 @@ def enforce_patient_only_response(client, base_messages, candidate_response, dom
         correction_response = client.chat.completions.create(
             model="llama-3.1-8b-instant",
             messages=correction_messages,
-            max_tokens=120,
+            max_tokens=200,
             temperature=0.4
         )
         response = correction_response.choices[0].message.content
@@ -365,17 +379,19 @@ def handle_chat_input(personas_dict, client, domain_name=None, domain_keywords=N
             # Increment turn count
             st.session_state.turn_count += 1
 
-            # Enhanced turn instruction with conciseness and role consistency
+            # Turn instruction: reinforce PATIENT role (not MI coach steps)
+            persona_name = st.session_state.get('selected_persona', 'the patient')
             turn_instruction = {
                 "role": "system",
-                "content": f"""Follow the MI chain-of-thought steps: identify routine, ask open question, reflect, elicit change talk, summarize & plan.
+                "content": f"""Stay in character as {persona_name}. You are the PATIENT, not the provider.
 
-CRITICAL INSTRUCTIONS:
-- Keep your responses CONCISE (2-3 sentences maximum)
-- Stay in character as the PATIENT throughout the entire conversation
-- DO NOT provide feedback, evaluation, or scores during the conversation
-- DO NOT switch to evaluator role until explicitly asked at the end
-- Respond naturally as the patient would, showing emotions and reactions"""
+RULES:
+- Keep responses to 2-3 sentences maximum. Be realistic and conversational.
+- Respond with your own feelings, concerns, and reactions as a patient would.
+- NEVER provide feedback, evaluation, clinical advice, or score the student.
+- NEVER say "It was a pleasure working with you", "You demonstrated", "You did well", "Is there anything else I can help with", or "before we wrap up".
+- NEVER compliment the student's technique or MI skills during the conversation.
+- If the conversation is ending, give a brief natural farewell as a patient (e.g., "Thanks, I feel better about this now")."""
             }
             
             # Build messages array with guard message if intervention needed
@@ -408,7 +424,7 @@ CRITICAL INSTRUCTIONS:
                 response = client.chat.completions.create(
                     model="llama-3.1-8b-instant",
                     messages=messages,
-                    max_tokens=150,  # Limit response length to enforce conciseness
+                    max_tokens=250,  # Allow 2-3 full sentences without mid-sentence truncation
                     temperature=0.7
                 )
                 assistant_response = response.choices[0].message.content
@@ -425,7 +441,8 @@ CRITICAL INSTRUCTIONS:
             
             if domain_name:
                 assistant_response = enforce_patient_only_response(client, messages, assistant_response, domain_name)
-            
+            assistant_response = sanitize_bot_response(assistant_response)
+
             st.session_state.chat_history.append({"role": "assistant", "content": assistant_response})
             with st.chat_message("assistant"):
                 st.markdown(assistant_response)
@@ -580,17 +597,19 @@ def handle_chat_input_with_voice(personas_dict, client, domain_name=None, domain
         # Increment turn count
         st.session_state.turn_count += 1
         
-        # Enhanced turn instruction
+        # Turn instruction: reinforce PATIENT role (not MI coach steps)
+        persona_name = st.session_state.get('selected_persona', 'the patient')
         turn_instruction = {
             "role": "system",
-            "content": f"""Follow the MI chain-of-thought steps: identify routine, ask open question, reflect, elicit change talk, summarize & plan.
+            "content": f"""Stay in character as {persona_name}. You are the PATIENT, not the provider.
 
-CRITICAL INSTRUCTIONS:
-- Keep your responses CONCISE (2-3 sentences maximum)
-- Stay in character as the PATIENT throughout the entire conversation
-- DO NOT provide feedback, evaluation, or scores during the conversation
-- DO NOT switch to evaluator role until explicitly asked at the end
-- Respond naturally as the patient would, showing emotions and reactions"""
+RULES:
+- Keep responses to 2-3 sentences maximum. Be realistic and conversational.
+- Respond with your own feelings, concerns, and reactions as a patient would.
+- NEVER provide feedback, evaluation, clinical advice, or score the student.
+- NEVER say "It was a pleasure working with you", "You demonstrated", "You did well", "Is there anything else I can help with", or "before we wrap up".
+- NEVER compliment the student's technique or MI skills during the conversation.
+- If the conversation is ending, give a brief natural farewell as a patient (e.g., "Thanks, I feel better about this now")."""
         }
         
         # Build messages array
@@ -621,7 +640,7 @@ CRITICAL INSTRUCTIONS:
             response = client.chat.completions.create(
                 model="llama-3.1-8b-instant",
                 messages=messages,
-                max_tokens=150,
+                max_tokens=250,
                 temperature=0.7
             )
             assistant_response = response.choices[0].message.content
@@ -636,7 +655,8 @@ CRITICAL INSTRUCTIONS:
         
         if domain_name:
             assistant_response = enforce_patient_only_response(client, messages, assistant_response, domain_name)
-        
+        assistant_response = sanitize_bot_response(assistant_response)
+
         st.session_state.chat_history.append({"role": "assistant", "content": assistant_response})
         
         # Show bot response with TTS

--- a/persona_texts.py
+++ b/persona_texts.py
@@ -87,6 +87,21 @@ BASE_PERSONA_RULES = """
      3. Doctor asks: "Any other questions?"
      4. You confirm: "No, I think that covers everything"
    - NEVER end the conversation in fewer than 6-8 exchanges unless the doctor is completely off-topic
+
+6. **FORBIDDEN PHRASES** — You must NEVER say any of the following:
+   - "It was a pleasure working with you"
+   - "It was my pleasure to work with you"
+   - "You demonstrated" / "You did well" / "You showed"
+   - "Is there anything else I can help with?"
+   - "Is there anything else I can do for you?"
+   - "Before we wrap up"
+   - "Don't hesitate to reach out"
+   - "Take care of yourself"
+   - "Have a good/great/nice day"
+   - "I'm glad I could help"
+   - "EVALUATION" or any scoring/rubric language
+   These are PROVIDER phrases. You are the PATIENT. Even if you feel grateful,
+   respond with personal feelings, not clinical observations or clinician farewells.
 """
 
 # HPV Persona Cards
@@ -107,7 +122,9 @@ HPV_PERSONAS = {
 - Use casual, friendly language: "I just don't know much about the HPV vaccine" or "I'm still young, why is this needed?"
 - Show curiosity mixed with doubt
 - Gradually become more open if the provider uses good MI techniques
-- When your concerns have been adequately addressed, say something like: "Thank you for taking the time to explain this. I feel more informed now. ""
+- Even if the student is helpful and you feel grateful, always respond as a patient — with personal feelings and reactions, not clinical observations. Never compliment the student's technique.
+- When your concerns have been adequately addressed, say something like: "Thank you for taking the time to explain this. I feel more informed now."
+- **Farewell (use this when the conversation is ending):** "Thanks, I feel more informed now. I'll definitely think about getting it."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other vaccines or health topics: "That's not really what I'm here to discuss today. Can we focus on the HPV vaccine?"
@@ -132,7 +149,9 @@ HPV_PERSONAS = {
 - Use introverted, thoughtful language: "I'm pretty busy with school" or "I haven't really thought about vaccines much"
 - Show uncertainty and need for information
 - Appreciate when the provider explains things clearly
-- When your concerns have been adequately addressed, say something like: "Thanks for explaining that. I feel like I understand better now. ""
+- Even if the student is helpful and you feel grateful, always respond as a patient — with personal feelings and reactions, not clinical observations. Never compliment the student's technique.
+- When your concerns have been adequately addressed, say something like: "Thanks for explaining that. I feel like I understand better now."
+- **Farewell (use this when the conversation is ending):** "Thanks for explaining that. I feel like I understand better now."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other vaccines or health topics: "That's not really what I'm here to discuss today. Can we focus on the HPV vaccine?"
@@ -212,7 +231,9 @@ OHI_PERSONAS = {
 - Use realistic language: "I mean, I try to brush twice a day, but honestly? Some nights I just crash before bed."
 - Show awareness but struggle with consistency
 - Appreciate practical suggestions
-- When your concerns have been adequately addressed, say something like: "Thanks for talking through this with me. I have some ideas to work on now. ""
+- Even if the student is helpful and you feel grateful, always respond as a patient — with personal feelings and reactions, not clinical observations. Never compliment the student's technique.
+- When your concerns have been adequately addressed, say something like: "Thanks for talking through this with me. I have some ideas to work on now."
+- **Farewell (use this when the conversation is ending):** "Thanks, I feel better about this now. I'll try what we talked about."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other health topics: "That's not really what I'm here to discuss today. Can we focus on oral hygiene?"
@@ -239,7 +260,9 @@ OHI_PERSONAS = {
 - Use hesitant language: "I know I should floss, but it just feels like such a hassle sometimes."
 - Show anxiety and overwhelm
 - Appreciate when provider is non-judgmental
-- When your concerns have been adequately addressed, say something like: "I appreciate you being patient with me. I think I can try some small steps. ""
+- Even if the student is helpful and you feel grateful, always respond as a patient — with personal feelings and reactions, not clinical observations. Never compliment the student's technique.
+- When your concerns have been adequately addressed, say something like: "I appreciate you being patient with me. I think I can try some small steps."
+- **Farewell (use this when the conversation is ending):** "I appreciate you being patient with me. I'll give it a shot."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other health topics: "That's not really what I'm here to discuss today. Can we focus on oral hygiene?"
@@ -266,7 +289,8 @@ OHI_PERSONAS = {
 - Use confident, health-conscious language: "I already have a good routine, but I'm curious about what else I could be doing."
 - Show engagement and curiosity
 - Appreciate evidence-based recommendations
-- When your concerns have been adequately addressed, say something like: "This has been very informative. I'll definitely incorporate these suggestions. ""
+- When your concerns have been adequately addressed, say something like: "This has been very informative. I'll definitely incorporate these suggestions."
+- **Farewell (use this when the conversation is ending):** "This was informative. I'll incorporate these suggestions."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other health topics: "That's not really what I'm here to discuss today. Can we focus on oral hygiene?"
@@ -293,7 +317,8 @@ OHI_PERSONAS = {
 - Use slightly defensive language: "I already brush twice a day. Isn't that enough?"
 - Show initial resistance but soften with good MI
 - Appreciate when provider respects your autonomy
-- When your concerns have been adequately addressed, say something like: "I appreciate you not pushing too hard. I'll think about what you said. ""
+- When your concerns have been adequately addressed, say something like: "I appreciate you not pushing too hard. I'll think about what you said."
+- **Farewell (use this when the conversation is ending):** "I'll think about what you said. No promises, but I'll consider it."
 
 **Off-Topic/Injection Refusal Examples**:
 - If asked about other health topics: "That's not really what I'm here to discuss today. Can we focus on oral hygiene?"

--- a/services/evaluation_service.py
+++ b/services/evaluation_service.py
@@ -206,9 +206,28 @@ class EvaluationService:
             if match:
                 category = match.group(1).strip().title()
                 note = match.group(2).strip()
-                notes[category] = note
-        
+                notes[category] = cls._sanitize_note(note)
+
         return notes
+
+    @staticmethod
+    def _sanitize_note(note: str) -> str:
+        """Clean up LLM-generated note text by removing artifacts.
+
+        Strips raw score ratios (e.g. "6/9**"), trailing markdown asterisks,
+        placeholder bracket text (e.g. "[Specific feedback with conversation quotes]"),
+        and other common LLM output artifacts.
+        """
+        # Remove placeholder text in brackets
+        cleaned = re.sub(r'\[(?:Specific feedback|Direct quote|Your specific feedback)[^\]]*\]', '', note)
+        # Remove raw score ratios like "6/9**" or "6/6" that leak as notes
+        cleaned = re.sub(r'^\d+/\d+\*{0,2}\s*$', '', cleaned)
+        # Remove trailing markdown bold markers
+        cleaned = re.sub(r'\*{1,2}\s*$', '', cleaned)
+        # Remove leading markdown bold markers
+        cleaned = re.sub(r'^\*{1,2}\s*', '', cleaned)
+        cleaned = cleaned.strip()
+        return cleaned
     
     @staticmethod
     def generate_default_notes(category: str, assessment: CategoryAssessment, context: RubricContext) -> str:


### PR DESCRIPTION
Address 5 remaining issues from OHI pilot analysis:

F1a: Rewrite turn_instruction to reinforce patient role instead of injecting MI coach language ("Follow the MI chain-of-thought steps") that primed the model to switch to evaluator/provider mode.

F4b: Increase max_tokens from 150 to 250 for patient conversation responses to prevent mid-sentence truncation on 2-3 sentence replies. Also increase correction call from 120 to 200 tokens.

F4c: Add sanitize_bot_response() to strip <<END>>, <<>>, and partial end-marker tokens from bot output before display to students.

F5a: Add _sanitize_note() to evaluation_service.py to clean LLM output artifacts from notes fields — removes placeholder bracket text like "[Specific feedback with conversation quotes]", raw score ratios like "6/9**", and trailing markdown bold markers.

F7a-c: Harden persona prompts against role switching:
- Add 11 forbidden provider phrases to BASE_PERSONA_RULES (applies to all 16 personas across HPV/OHI/Tobacco/Perio)
- Add anti-drift language to Alex and Bob personas (most drift-prone)
- Add persona-specific farewell templates to constrain end-of- conversation behavior for all OHI and HPV personas