### PR TITLE
Fix startup log spam: suppress 4,268 torchvision import errors

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,18 @@
+[server]
+# Exclude heavy ML libraries from Streamlit's file watcher.
+# The transformers library has hundreds of vision model sub-modules that each
+# try to import torchvision (not installed), producing ~4,000 ModuleNotFoundError
+# tracebacks on every startup. These packages never change at runtime, so
+# watching them is pure overhead.
+folderWatchBlacklist = [
+    "**/transformers/**",
+    "**/torch/**",
+    "**/sentence_transformers/**",
+    "**/faiss/**",
+    "**/numpy/**",
+    "**/reportlab/**",
+]
+
+[logger]
+# Suppress noisy transformers import warnings in Streamlit logs
+level = "warning"

--- a/secret_code_portal.py
+++ b/secret_code_portal.py
@@ -34,6 +34,15 @@ Requirements:
 """
 
 import os
+
+# Suppress transformers library warnings BEFORE any imports touch it.
+# The transformers package (pulled in by sentence-transformers) tries to load
+# hundreds of vision model sub-modules that require torchvision (not installed),
+# producing thousands of ModuleNotFoundError tracebacks on every app startup.
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
 import logging
 import streamlit as st
 from streamlit.errors import StreamlitAPIException


### PR DESCRIPTION
The transformers library (dependency of sentence-transformers) has hundreds of vision model sub-modules that each try to import torchvision, which is not installed. Streamlit's file watcher scans all of them on every startup, producing ~4,268 identical ModuleNotFoundError tracebacks that flood the logs (104K lines of noise) and slow down app startup.

Fixes:
- Add .streamlit/config.toml with folderWatchBlacklist to exclude transformers, torch, sentence_transformers, faiss, numpy, and reportlab from Streamlit's file watcher
- Set TRANSFORMERS_VERBOSITY=error, TRANSFORMERS_NO_ADVISORY_WARNINGS=1, and TOKENIZERS_PARALLELISM=false environment variables before any imports in secret_code_portal.py to suppress warnings at the source
- Set Streamlit logger level to warning to filter noisy import messages