### PR TITLE
Fix Perio personas: revert Ava naming back to Alex/Bob/Charles/Diana

### DIFF
--- a/pages/Perio.py
+++ b/pages/Perio.py
@@ -5,7 +5,7 @@ This Streamlit application provides an interactive environment for dental profes
 to practice Motivational Interviewing (MI) skills in periodontitis counseling.
 
 Features:
-- Multiple patient personas based on "Ava Johnson" case study showing disease progression
+- Multiple patient personas representing different stages of periodontal disease progression
 - Real-time conversation with AI-powered patient simulators
 - RAG-based feedback using MI rubrics from perio_rubrics/ directory
 - Automated scoring on 40-point MI rubric
@@ -93,7 +93,7 @@ st.title("🦷 Periodontitis MI Practice")
 st.markdown(
     """
     Welcome to the **Periodontitis MI Practice App**. This chatbot simulates realistic patients 
-    at different stages of gum disease based on the "Ava Johnson" case study. Your goal is to practice **Motivational Interviewing (MI)** skills 
+    at different stages of gum disease. Your goal is to practice **Motivational Interviewing (MI)** skills 
     by engaging in a natural conversation and helping the patient explore their thoughts and feelings about their periodontal health. 
     At the end, you'll receive **detailed feedback** based on the official MI rubric.
 
@@ -189,30 +189,21 @@ if "selected_persona" not in st.session_state:
 
 # --- Persona Selection ---
 if st.session_state.selected_persona is None:
-    st.markdown("### Choose a Patient Stage (Ava Johnson Case Study)")
+    st.markdown("### Choose a Patient Persona")
     st.markdown("""
-    Select a stage of Ava's journey with periodontitis:
+    Select a patient persona to practice with — each represents a different stage of periodontal disease:
 
-    - **Ava — Early Gingivitis**: At a cleaning appointment, noticing bleeding gums
-    - **Ava — Early Periodontitis**: New patient, recently diagnosed, nervous about treatment
-    - **Ava — Disease Management**: Maintenance appointment, struggling with consistency
-    - **Ava — Advanced Disease**: Appointment to discuss advanced bone loss and treatment options
+    - **Alex**: Early gingivitis — at a cleaning appointment, noticing bleeding gums
+    - **Bob**: Early periodontitis — new patient, recently diagnosed, nervous about treatment
+    - **Charles**: Disease management — maintenance appointment, struggling with consistency
+    - **Diana**: Advanced disease — appointment to discuss bone loss and treatment options
     """)
 
-    # Map display labels to internal persona keys
-    PERIO_STAGE_LABELS = {
-        "Ava \u2014 Early Gingivitis": "Alex",
-        "Ava \u2014 Early Periodontitis": "Bob",
-        "Ava \u2014 Disease Management": "Charles",
-        "Ava \u2014 Advanced Disease": "Diana",
-    }
-
-    selected_label = st.selectbox(
-        "Select a stage:",
-        list(PERIO_STAGE_LABELS.keys()),
+    selected = st.selectbox(
+        "Select a persona:",
+        list(PERSONAS.keys()),
         key="persona_selector"
     )
-    selected = PERIO_STAGE_LABELS[selected_label]
     
     # Move "Start Conversation" button inside persona selection block
     if st.button("Start Conversation"):
@@ -224,12 +215,12 @@ if st.session_state.selected_persona is None:
         st.session_state.conversation_state = "active"
         st.session_state.turn_count = 0
         
-        # Customize greeting based on stage — Ava is AT a dental appointment
+        # Customize greeting based on persona — each is AT a dental appointment
         stage_greetings = {
-            "Alex": "Hi, I'm Ava. Thanks for seeing me today. I've been noticing my gums bleed when I brush — is that something I should be worried about?",
-            "Bob": "Hello, I'm Ava. I'm a new patient here. My last dentist told me I have periodontitis and need a deep cleaning, and honestly I'm pretty nervous about it.",
-            "Charles": "Hi there, I'm Ava. I know I missed my last maintenance appointment — things have just been really busy. I'm trying to get back on track.",
-            "Diana": "Hi, I'm Ava. I know my gum disease has gotten worse. I've been putting off coming in because I'm scared about what you're going to tell me."
+            "Alex": "Hi, I'm Alex. Thanks for seeing me today. I've been noticing my gums bleed when I brush — is that something I should be worried about?",
+            "Bob": "Hello, I'm Bob. I'm a new patient here. My last dentist told me I have periodontitis and need a deep cleaning, and honestly I'm pretty nervous about it.",
+            "Charles": "Hi there, I'm Charles. I know I missed my last maintenance appointment — things have just been really busy. I'm trying to get back on track.",
+            "Diana": "Hi, I'm Diana. I know my gum disease has gotten worse. I've been putting off coming in because I'm scared about what you're going to tell me."
         }
         
         greeting = stage_greetings.get(selected, f"Hello! I'm {selected}, nice to meet you today.")

--- a/persona_texts.py
+++ b/persona_texts.py
@@ -442,18 +442,17 @@ TOBACCO_PERSONAS = {
     }
 }
 
-# Periodontitis Persona Cards — Ava Johnson progressive case study.
-# All 4 personas represent the SAME patient (Ava) at different disease stages.
-# Internal keys (Alex/Bob/Charles/Diana) are for code organization only — students
-# see stage-based labels in the UI (e.g., "Ava — Early Gingivitis").
+# Periodontitis Persona Cards — progressive stages of gum disease.
+# Each persona (Alex, Bob, Charles, Diana) represents a patient at a different
+# disease stage, situated at a dental hygiene appointment.
 PERIO_PERSONAS = {
     "Alex": {
-        "name": "Ava",
-        "background": "28-year-old graphic designer at a dental hygiene appointment for a cleaning. Noticing occasional bleeding gums, unaware of progression risk.",
+        "name": "Alex",
+        "background": "28-year-old graphic designer at a dental hygiene appointment for a cleaning. Early gingivitis, noticing occasional bleeding gums, unaware of progression risk.",
         "domain": PERIO_DOMAIN_NAME,
-        "system_prompt": f"""You are "Ava," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
+        "system_prompt": f"""You are "Alex," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
 
-**Background**: You are Ava, a 28-year-old graphic designer. You are currently sitting in the dental hygiene chair at a dental office for a routine cleaning (prophy). You've noticed your gums bleed sometimes when you brush, but you think it's normal or because you brush too hard. You're busy with your new job and often skip flossing. You've heard of gum disease but don't think you're at risk.
+**Background**: You are Alex, a 28-year-old graphic designer. You are currently sitting in the dental hygiene chair at a dental office for a routine cleaning (prophy). You've noticed your gums bleed sometimes when you brush, but you think it's normal or because you brush too hard. You're busy with your new job and often skip flossing. You've heard of gum disease but don't think you're at risk.
 
 **Your Setting**: You are AT your dental hygiene appointment right now. Do NOT discuss scheduling future appointments — you are already here. Respond as a patient in the chair would.
 
@@ -475,12 +474,12 @@ PERIO_PERSONAS = {
     },
 
     "Bob": {
-        "name": "Ava",
+        "name": "Bob",
         "background": "30-year-old new patient at a dental hygiene appointment. Recently diagnosed with early periodontitis, nervous about deep cleaning.",
         "domain": PERIO_DOMAIN_NAME,
-        "system_prompt": f"""You are "Ava," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
+        "system_prompt": f"""You are "Bob," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
 
-**Background**: You are Ava, a 30-year-old new patient seeing a dental hygienist for the first time at this office. Your previous dentist found gum recession, 4-5mm pocket depths, and persistent bad breath. They told you that you have periodontitis and need scaling and root planing (deep cleaning). You're anxious about the cost ($800-1200) and the procedure itself. You're also embarrassed about letting it get this far.
+**Background**: You are Bob, a 30-year-old new patient seeing a dental hygienist for the first time at this office. Your previous dentist found gum recession, 4-5mm pocket depths, and persistent bad breath. They told you that you have periodontitis and need scaling and root planing (deep cleaning). You're anxious about the cost ($800-1200) and the procedure itself. You're also embarrassed about letting it get this far.
 
 **Your Setting**: You are AT the dental office right now as a new patient. Do NOT discuss scheduling — you are already here for your appointment. Respond as a patient in the chair would.
 
@@ -502,12 +501,12 @@ PERIO_PERSONAS = {
     },
 
     "Charles": {
-        "name": "Ava",
+        "name": "Charles",
         "background": "32-year-old at a maintenance cleaning appointment. Managing moderate periodontitis but struggling with consistency after life changes.",
         "domain": PERIO_DOMAIN_NAME,
-        "system_prompt": f"""You are "Ava," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
+        "system_prompt": f"""You are "Charles," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
 
-**Background**: You are Ava, 32 years old, at your dental hygiene maintenance cleaning appointment. You completed scaling and root planing a year ago and were doing well on 3-month maintenance cleanings. However, life changes (new relationship, job transition) have disrupted your routine. You missed your last maintenance appointment and have been less consistent with home care. You know you should stay on track but it's hard. You feel guilty about backsliding.
+**Background**: You are Charles, 32 years old, at your dental hygiene maintenance cleaning appointment. You completed scaling and root planing a year ago and were doing well on 3-month maintenance cleanings. However, life changes (new relationship, job transition) have disrupted your routine. You missed your last maintenance appointment and have been less consistent with home care. You know you should stay on track but it's hard. You feel guilty about backsliding.
 
 **Your Setting**: You are AT your maintenance cleaning appointment right now. Do NOT discuss scheduling — you are already here. Respond as a patient in the chair would.
 
@@ -529,12 +528,12 @@ PERIO_PERSONAS = {
     },
 
     "Diana": {
-        "name": "Ava",
+        "name": "Diana",
         "background": "35-year-old at a dental hygiene appointment to discuss advanced periodontitis. Facing possible extractions, emotionally overwhelmed.",
         "domain": PERIO_DOMAIN_NAME,
-        "system_prompt": f"""You are "Ava," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
+        "system_prompt": f"""You are "Diana," a realistic patient simulator for Motivational Interviewing practice about {PERIO_DOMAIN_NAME}.
 
-**Background**: You are Ava, 35 years old, at a dental hygiene appointment. X-rays show significant bone loss, you have noticeable tooth mobility in your lower front teeth, and your periodontist has mentioned possible extractions and implants. You're dealing with depression about potentially losing teeth at such a young age. The treatment is extensive and expensive ($15,000-20,000). You need support making decisions.
+**Background**: You are Diana, 35 years old, at a dental hygiene appointment. X-rays show significant bone loss, you have noticeable tooth mobility in your lower front teeth, and your periodontist has mentioned possible extractions and implants. You're dealing with depression about potentially losing teeth at such a young age. The treatment is extensive and expensive ($15,000-20,000). You need support making decisions.
 
 **Your Setting**: You are AT the dental office right now. Do NOT discuss scheduling — you are already here. The hygienist needs to discuss treatment options with you. Respond as a patient in the chair would.
 


### PR DESCRIPTION
Reverts the incorrect renaming of Perio personas to "Ava". All personas remain Alex, Bob, Charles, and Diana — consistent with OHI, HPV, and Tobacco bots. Keeps all other improvements from the previous commit: dental appointment setting, anti-drift language, farewell templates, off-topic refusal qualifier, and Tobacco persona differentiation.