### PR TITLE
Fix three audit items: email queue, Groq env race, dead rubric load

### DIFF
--- a/email_queue.py
+++ b/email_queue.py
@@ -92,42 +92,35 @@ class EmailQueue:
     def remove(self, entry_id: str) -> bool:
         """
         Remove processed email from queue.
-        
+
         Args:
             entry_id: Queue entry ID to remove
-            
+
         Returns:
             True if entry was found and removed, False otherwise
         """
         queue = self._load()
-        original_len = len(queue)
-        
-        # Find and remove entry
-        removed_entry = None
+
+        removed_entry = next((e for e in queue if e.get('id') == entry_id), None)
+        if removed_entry is None:
+            logger.warning(f"Email queue entry not found: {entry_id}")
+            return False
+
         queue = [e for e in queue if e.get('id') != entry_id]
-        
-        if len(queue) < original_len:
-            # Delete associated PDF file
-            for entry in self._load():
-                if entry.get('id') == entry_id:
-                    removed_entry = entry
-                    break
-            
-            if removed_entry and 'pdf_path' in removed_entry:
-                pdf_path = Path(removed_entry['pdf_path'])
-                if pdf_path.exists():
-                    try:
-                        pdf_path.unlink()
-                        logger.debug(f"Deleted PDF file: {pdf_path}")
-                    except Exception as e:
-                        logger.warning(f"Failed to delete PDF file {pdf_path}: {e}")
-            
-            self._save(queue)
-            logger.info(f"Removed email from queue: {entry_id}")
-            return True
-        
-        logger.warning(f"Email queue entry not found: {entry_id}")
-        return False
+
+        pdf_path_str = removed_entry.get('pdf_path')
+        if pdf_path_str:
+            pdf_path = Path(pdf_path_str)
+            if pdf_path.exists():
+                try:
+                    pdf_path.unlink()
+                    logger.debug(f"Deleted PDF file: {pdf_path}")
+                except Exception as e:
+                    logger.warning(f"Failed to delete PDF file {pdf_path}: {e}")
+
+        self._save(queue)
+        logger.info(f"Removed email from queue: {entry_id}")
+        return True
     
     def increment_retry_count(self, entry_id: str) -> Optional[int]:
         """

--- a/mi_session.py
+++ b/mi_session.py
@@ -25,7 +25,6 @@ Public surface:
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -335,36 +334,6 @@ def _render_feedback_section(config: SessionConfig) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Knowledge base loader (rubric files; kept page-local so each session can
-# resolve its own rubrics_dir relative to the worktree root).
-# ---------------------------------------------------------------------------
-
-
-def _load_rubric_text(rubric_dir_name: str) -> str:
-    """Read all .txt files under <repo_root>/<rubric_dir_name> and concatenate."""
-    from pathlib import Path
-
-    here = Path(__file__).resolve().parent
-    candidates = [here / rubric_dir_name, here.parent / rubric_dir_name]
-    rubric_dir = next((p for p in candidates if p.exists() and p.is_dir()), None)
-    if rubric_dir is None:
-        st.error(f"Configuration error: rubric directory '{rubric_dir_name}' not found.")
-        st.stop()
-
-    texts: List[str] = []
-    for path in sorted(rubric_dir.glob("*.txt")):
-        try:
-            texts.append(path.read_text(encoding="utf-8", errors="ignore"))
-        except OSError as exc:
-            logger.warning("could not read rubric file %s: %s", path, exc)
-
-    if not texts:
-        st.error(f"No rubric files in {rubric_dir}.")
-        st.stop()
-    return "\n\n".join(texts)
-
-
-# ---------------------------------------------------------------------------
 # Persona selection UI
 # ---------------------------------------------------------------------------
 
@@ -404,17 +373,13 @@ def run_practice_session(config: SessionConfig) -> None:
     st.title(f"{config.page_icon} {config.page_title}")
     st.markdown(config.intro_markdown, unsafe_allow_html=True)
 
-    # Initialize Groq client from session credentials.
-    os.environ["GROQ_API_KEY"] = st.session_state.groq_api_key
-    client = Groq()
+    # Initialize Groq client from session credentials. Pass the key directly
+    # rather than mutating os.environ, which is process-global and would race
+    # under concurrent users.
+    client = Groq(api_key=st.session_state.groq_api_key)
 
     _initialize_state(config)
     persona_prompts = _personas_to_prompt_dict(config.personas)
-
-    # Load rubrics once (kept for future RAG reintegration; currently unused
-    # because the strict-JSON evaluator does not require a separate retrieval
-    # context — its system prompt is self-contained).
-    _ = _load_rubric_text(config.rubric_dir_name)
 
     _persona_selection(config, persona_prompts)
 

--- a/tests/test_email_queue.py
+++ b/tests/test_email_queue.py
@@ -1,0 +1,90 @@
+"""Test suite for email_queue.EmailQueue."""
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from email_queue import EmailQueue
+
+
+class TestEmailQueueRemove(unittest.TestCase):
+    """Tests for EmailQueue.remove() — the path the recent fix targeted."""
+
+    def setUp(self):
+        self.queue_dir = tempfile.mkdtemp()
+        self.queue = EmailQueue(queue_dir=self.queue_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.queue_dir, ignore_errors=True)
+
+    def _add_entry(self, name: str = "alice") -> str:
+        return self.queue.add(
+            pdf_data=b"%PDF-1.4 test",
+            filename=f"{name}.pdf",
+            recipient="box@example.com",
+            student_name=name,
+            session_type="OHI",
+        )
+
+    def test_remove_existing_entry_returns_true_and_drops_it(self):
+        entry_id = self._add_entry()
+        self.assertEqual(self.queue.get_queue_size(), 1)
+
+        self.assertTrue(self.queue.remove(entry_id))
+        self.assertEqual(self.queue.get_queue_size(), 0)
+
+    def test_remove_unknown_entry_returns_false_and_keeps_queue(self):
+        entry_id = self._add_entry()
+
+        self.assertFalse(self.queue.remove("nonexistent-id"))
+        self.assertEqual(self.queue.get_queue_size(), 1)
+        self.assertEqual(self.queue.get_pending()[0]["id"], entry_id)
+
+    def test_remove_deletes_associated_pdf_file(self):
+        entry_id = self._add_entry()
+        pdf_path = Path(self.queue.get_pending()[0]["pdf_path"])
+        self.assertTrue(pdf_path.exists())
+
+        self.queue.remove(entry_id)
+        self.assertFalse(pdf_path.exists())
+
+    def test_remove_loads_queue_file_only_once(self):
+        """Regression: previous version called _load() twice per remove()."""
+        entry_id = self._add_entry()
+
+        original_load = EmailQueue._load
+        with patch.object(EmailQueue, "_load", autospec=True, side_effect=original_load) as spy:
+            self.queue.remove(entry_id)
+
+        self.assertEqual(spy.call_count, 1)
+
+    def test_remove_only_drops_target_entry(self):
+        keep_id = self._add_entry("alice")
+        drop_id = self._add_entry("bob")
+
+        self.queue.remove(drop_id)
+
+        remaining = self.queue.get_pending()
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0]["id"], keep_id)
+
+    def test_remove_tolerates_entry_without_pdf_path(self):
+        entry_id = self._add_entry()
+        # Simulate a legacy/corrupt entry by stripping pdf_path on disk.
+        queue_file = Path(self.queue_dir) / EmailQueue.QUEUE_FILE
+        with open(queue_file, "r") as f:
+            data = json.load(f)
+        for entry in data:
+            entry.pop("pdf_path", None)
+        with open(queue_file, "w") as f:
+            json.dump(data, f)
+
+        self.assertTrue(self.queue.remove(entry_id))
+        self.assertEqual(self.queue.get_queue_size(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Three small but real fixes from the recent audit, none of which change observable behavior on the happy path.

### 1. `EmailQueue.remove()` — load once, no logic bug ([email_queue.py:92](https://github.com/manirathnam2001/ManiUMN-MI_chatbots/blob/main/email_queue.py#L92))
Previous version called `self._load()` twice and looked up the just-filtered entry in the second read — only worked because `_save()` hadn't run yet (an unreachable lookup that happened to succeed). Now finds the entry first, then filters and saves.

### 2. Groq client race under concurrent users ([mi_session.py:407-409](https://github.com/manirathnam2001/ManiUMN-MI_chatbots/blob/main/mi_session.py#L407))
`os.environ["GROQ_API_KEY"] = st.session_state.groq_api_key` mutates a process-global from per-user session state. Two Streamlit sessions running concurrently can clobber each other's keys. Fix: pass `Groq(api_key=...)` directly so each session's client is bound to its own key.

### 3. Per-rerun rubric file reads ([mi_session.py:417](https://github.com/manirathnam2001/ManiUMN-MI_chatbots/blob/main/mi_session.py#L417))
`_ = _load_rubric_text(config.rubric_dir_name)` re-read 2-3 `.txt` files on every Streamlit rerun and discarded the result into `_`. The strict-JSON evaluator's system prompt is self-contained, so the load was dead. Removed the call and the now-orphaned function (~30 lines).

Also drops the now-unused `import os`.

Net: **+26 / -68** across two files.

## Why this is safe
- `mi_evaluation.py` receives the Groq client as a parameter — it does not read `GROQ_API_KEY` from `os.environ` directly, so passing the key on the constructor is fully equivalent on the success path.
- `_load_rubric_text` had exactly one caller (the dead site we removed); no other module imports it.
- `EmailQueue.remove()`'s public contract is unchanged — same arguments, same return type, same logged events. The fix only collapses redundant disk reads.

## Test plan
- [ ] Streamlit app boots and the secret-code portal loads
- [ ] Each MI page (HPV, OHI, Perio, Tobacco) starts a session, accepts chat input, and successfully calls Groq (verifies `Groq(api_key=...)` works)
- [ ] Clicking "Generate Feedback" produces a scored evaluation
- [ ] Two concurrent sessions with different keys do not cross-contaminate (the original race fix)
- [ ] Failed-email retry path successfully calls `EmailQueue.remove()` after a successful retry; the queued PDF is deleted from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)