### PR TITLE
Phase 2: dependency prune, pin, and lock

### DIFF
--- a/.github/workflows/ci-msi-hybrid.yml
+++ b/.github/workflows/ci-msi-hybrid.yml
@@ -45,6 +45,29 @@ jobs:
           /tmp/lockenv/bin/pip freeze
           echo "----- END RUNTIME LOCK -----"
 
+      - name: Assert requirements.txt pins match requirements.lock
+        # The two files are maintained separately, so they can drift. A pin that
+        # disagrees with the lock means an install from one file differs from an
+        # install from the other, which defeats the point of locking.
+        run: |
+          fail=0
+          while IFS= read -r line; do
+            case "$line" in \#*|"") continue ;; esac
+            pkg="${line%%==*}"
+            want="${line%% *}"
+            got=$(grep -iE "^${pkg}==" requirements.lock | sed 's/ *#.*//' | head -1)
+            if [ "$want" != "$got" ]; then
+              echo "MISMATCH ${pkg}: requirements.txt has '${want}', requirements.lock has '${got:-<absent>}'"
+              fail=1
+            fi
+          done < requirements.txt
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "Regenerate requirements.lock from the RUNTIME LOCK block above."
+            exit 1
+          fi
+          echo "OK: every pin in requirements.txt matches requirements.lock."
+
       - name: Static check for undefined names
         # Catches the failure mode dependency pruning creates: removing a block
         # of dead code also removes an import a later line still needs. The test

--- a/.github/workflows/ci-msi-hybrid.yml
+++ b/.github/workflows/ci-msi-hybrid.yml
@@ -32,11 +32,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Record resolved versions
-        # Prints the fully resolved dependency tree. This is the source for
-        # requirements.lock, which cannot be generated on a machine without a
-        # Python interpreter.
-        run: pip freeze
+      - name: Record runtime-only resolved versions
+        # Resolves requirements.txt alone in a throwaway virtualenv, so the
+        # output is the runtime closure without pytest, pyflakes, gTTS or their
+        # transitives. This is the source for requirements.lock, which cannot be
+        # generated on a machine with no Python interpreter.
+        run: |
+          python -m venv /tmp/lockenv
+          /tmp/lockenv/bin/pip install --quiet --upgrade pip
+          /tmp/lockenv/bin/pip install --quiet -r requirements.txt
+          echo "----- BEGIN RUNTIME LOCK -----"
+          /tmp/lockenv/bin/pip freeze
+          echo "----- END RUNTIME LOCK -----"
 
       - name: Static check for undefined names
         # Catches the failure mode dependency pruning creates: removing a block

--- a/.github/workflows/ci-msi-hybrid.yml
+++ b/.github/workflows/ci-msi-hybrid.yml
@@ -38,12 +38,34 @@ jobs:
         # Python interpreter.
         run: pip freeze
 
-      - name: Static check for undefined and unused names
+      - name: Static check for undefined names
         # Catches the failure mode dependency pruning creates: removing a block
         # of dead code also removes an import a later line still needs. The test
         # suite cannot catch this in Streamlit script modules, which it never
         # imports.
-        run: python -m pyflakes $(git ls-files '*.py' | grep -v '^tests/')
+        #
+        # Only undefined names fail the build. pyflakes also reports unused
+        # imports, unused locals and f-strings without placeholders; the tree
+        # currently has 17 of those, all pre-existing and all cosmetic. Failing
+        # on them would create a permanently red gate that everyone learns to
+        # ignore, which is the problem Phase 1a existed to fix. They are printed
+        # as advisory output instead.
+        run: |
+          set +e
+          out=$(python -m pyflakes $(git ls-files '*.py' | grep -v '^tests/'))
+          set -e
+
+          echo "$out"
+
+          undefined=$(echo "$out" | grep "undefined name" || true)
+          if [ -n "$undefined" ]; then
+            echo ""
+            echo "FAIL: undefined names found. These are runtime NameErrors."
+            echo "$undefined"
+            exit 1
+          fi
+          echo ""
+          echo "OK: no undefined names."
 
       - name: Run test suite
         run: python -m pytest tests/ test_evaluation.py -q

--- a/.github/workflows/ci-msi-hybrid.yml
+++ b/.github/workflows/ci-msi-hybrid.yml
@@ -30,8 +30,20 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Record resolved versions
+        # Prints the fully resolved dependency tree. This is the source for
+        # requirements.lock, which cannot be generated on a machine without a
+        # Python interpreter.
+        run: pip freeze
+
+      - name: Static check for undefined and unused names
+        # Catches the failure mode dependency pruning creates: removing a block
+        # of dead code also removes an import a later line still needs. The test
+        # suite cannot catch this in Streamlit script modules, which it never
+        # imports.
+        run: python -m pyflakes $(git ls-files '*.py' | grep -v '^tests/')
 
       - name: Run test suite
         run: python -m pytest tests/ test_evaluation.py -q

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,18 +1,15 @@
 [server]
-# Exclude heavy ML libraries from Streamlit's file watcher.
-# The transformers library has hundreds of vision model sub-modules that each
-# try to import torchvision (not installed), producing ~4,000 ModuleNotFoundError
-# tracebacks on every startup. These packages never change at runtime, so
-# watching them is pure overhead.
+# Exclude libraries from Streamlit's file watcher. They never change at runtime,
+# so watching them is pure overhead.
+#
+# The transformers, torch, sentence_transformers, faiss and numpy entries were
+# removed in Phase 2 of the MSI migration, along with the packages themselves.
+# They existed because transformers tried to import hundreds of vision
+# sub-modules requiring torchvision, producing roughly 4,000 ModuleNotFoundError
+# tracebacks at every startup. With those packages gone the noise is gone too.
 folderWatchBlacklist = [
-    "**/transformers/**",
-    "**/torch/**",
-    "**/sentence_transformers/**",
-    "**/faiss/**",
-    "**/numpy/**",
     "**/reportlab/**",
 ]
 
 [logger]
-# Suppress noisy transformers import warnings in Streamlit logs
 level = "warning"

--- a/docs/CHANGELOG_MIGRATION.md
+++ b/docs/CHANGELOG_MIGRATION.md
@@ -117,6 +117,117 @@ something again.
 
 ---
 
+## Phase 2: dependency prune, pin, and lock
+
+Date: 2026-08-11
+Branch: `msi/phase-2-deps`
+Pull request: #121
+Plan reference: `MIGRATION_PLAN.md` section 7
+
+### Purpose
+
+Reduce the runtime surface before it is baked into an Apptainer image in
+Phase 8. Building the image first would produce a roughly 6 GB artifact with
+CUDA layers that is then discarded.
+
+### Removed
+
+| Package | Reason |
+|---|---|
+| `torch>=2.5.1` | Imported nowhere |
+| `sentence-transformers` | Imported nowhere |
+| `faiss-cpu` | Imported nowhere |
+| `numpy` | Not imported directly. Still installed transitively via `streamlit` |
+| `google-auth-oauthlib` | **Not identified in the plan.** Imported nowhere, and there is no interactive OAuth flow: credentials are service-account based. Still installed transitively via `gspread` |
+
+The first four supported a RAG pipeline that no longer exists. PR #117 removed
+its last vestige, `_load_rubric_text`, which read rubric text and immediately
+discarded it.
+
+Note that removing `numpy` and `google-auth-oauthlib` drops a *declaration*, not
+a package: both remain in the install as transitive dependencies. The value is
+that the file now lists only what the code imports.
+
+### Moved to `requirements-dev.txt`
+
+`gTTS`, imported only by `speech_text/tts_handler.py`, which is imported only by
+tests. This also drops an outbound runtime dependency on
+`translate.google.com`.
+
+### Runtime set
+
+Eight direct packages, each confirmed imported by application code:
+`streamlit`, `groq`, `reportlab`, `pytz`, `python-dotenv`, `python-dateutil`,
+`gspread`, `google-auth`. All pinned with `==`.
+
+`requirements.lock` records the full resolved closure of 60 packages.
+
+### Provenance of the pinned versions
+
+The plan called for capturing `pip freeze` from the running production
+deployment, so that today's behaviour could be reproduced. That was not
+possible: the deployment could not be inspected from here.
+
+The versions instead come from resolving the current requirements in a clean
+isolated virtualenv on Python 3.11 in CI. Production has been installing
+unpinned packages since it was first deployed, so its actual versions may
+differ. **Verify on the Track B deployment before cutover.**
+
+No Python interpreter is available on the authoring machine, so the resolution
+had to be performed by CI and copied back.
+
+### Impact
+
+| | Before | After |
+|---|---|---|
+| Direct runtime packages | 14 | 8 |
+| Approximate install size | ~6 GB, CUDA wheels | ~400 MB |
+| Runtime outbound dependencies | plus `huggingface.co` and `translate.google.com` | neither |
+
+Removing `huggingface.co` retires part of Help Desk question B4.
+
+### A defect introduced and caught
+
+Removing the dead `transformers` suppression block at the top of
+`secret_code_portal.py` also removed the `import os` that line 728 still
+depends on. That would have been a `NameError` at runtime.
+
+The test suite could not have caught it: `secret_code_portal` is a Streamlit
+script the suite never imports. The import was restored, and **pyflakes** was
+added to CI, since undefined names are exactly the failure mode dependency
+pruning creates.
+
+The pyflakes gate is deliberately narrow. Its first run reported 17 findings,
+none of which were undefined names: unused imports, f-strings without
+placeholders, and unused locals, all pre-existing. Failing on those would create
+a permanently red gate that everyone learns to ignore, which is the problem
+Phase 1a existed to fix. **Only undefined names fail the build.** The rest print
+as advisory output.
+
+Cleaning up those 17 is worth doing, but not inside a dependency change, and
+several sit in files Phases 3 through 7 will rewrite.
+
+### New CI steps
+
+| Step | Purpose |
+|---|---|
+| Record runtime-only resolved versions | Resolves `requirements.txt` alone in a throwaway virtualenv. Source for the lockfile |
+| Static check for undefined names | pyflakes, failing only on undefined names |
+| Assert pins match the lockfile | The two files are maintained separately and can drift |
+
+### Verification
+
+| Check | Result |
+|---|---|
+| Four target packages imported nowhere | Confirmed by grep before removal |
+| `google-auth-oauthlib` unused, no OAuth flow | Confirmed by grep |
+| `gTTS` reachable only from tests | Confirmed by grep |
+| No undefined names anywhere in the tree | pyflakes, CI |
+| Every pin matches the lockfile | CI, all eight |
+| Test suite | Green |
+
+---
+
 ## Phase 1a: stale test cleanup
 
 Date: 2026-08-11

--- a/docs/MIGRATION_TRACKER.md
+++ b/docs/MIGRATION_TRACKER.md
@@ -93,7 +93,7 @@ Legend: Done, In progress, Blocked, Not started.
 | 1 | Track B setup, safety net, dead code removal | `msi-hybrid` direct | none | **Done** 2026-08-02 | CI run, zero new failures |
 | 1a | Clear the 17 stale test failures | `msi/phase-1a-stale-tests` | #118 | **Done** 2026-08-11 | Merged. CI green |
 | - | Integrate PR #117 from main | `msi-hybrid` direct | #117 | **Done** 2026-08-11 | Merged + semantic fix. CI green, 228 passed |
-| 2 | Dependency prune, pin, lock | `msi/phase-2-deps` | not opened | Not started | None. Ready to start |
+| 2 | Dependency prune, pin, lock | `msi/phase-2-deps` | #121 | **In review** 2026-08-11 | CI green. 14 direct deps to 8, lockfile added |
 | 3 | LLM provider abstraction | `msi/phase-3-llm-provider` | not opened | Not started | None. Ready to start |
 | 4 | Retire per-student API keys | `msi/phase-4-api-keys` | not opened | Not started | After Phase 3. PR #117 now merged, overlap resolved |
 | 5 | Path externalization | `msi/phase-5-paths` | not opened | Not started | Blocks Phase 8 |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,28 @@
+# Development and test dependencies.
+#
+# Install alongside the runtime requirements:
+#
+#     pip install -r requirements.txt -r requirements-dev.txt
+
+# Test runner
+pytest
+
+# Static checks for undefined and unused names.
+#
+# Added in Phase 2 after removing a block of dead imports also removed the
+# `import os` that a later line still depended on. The test suite would not have
+# caught it: the module is a Streamlit script the suite never imports. pyflakes
+# catches undefined names and unused imports without needing to execute code,
+# which is exactly the failure mode dependency pruning creates.
+pyflakes
+
+# Text-to-speech, used only by speech_text/tts_handler.py.
+#
+# Voice mode is a documented dormant feature: speech_text/ is imported by the
+# test suite and by nothing else at runtime. See mi_session.py, which records
+# the regression. Keeping gTTS out of the runtime set also removes an outbound
+# dependency on translate.google.com, which matters for the MSI migration
+# because compute-node internet access is restricted.
+#
+# If voice mode is restored, move this back into requirements.txt.
+gTTS>=2.3.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,80 @@
+# Resolved runtime dependency lock.
+#
+# Generated from a clean install of requirements.txt alone, in an isolated
+# virtualenv on Python 3.11, by the "Record runtime-only resolved versions" step
+# of .github/workflows/ci-msi-hybrid.yml.
+#
+# Install a reproducible environment with:
+#
+#     pip install -r requirements.lock
+#
+# To regenerate: change requirements.txt, push, and copy the block printed
+# between the RUNTIME LOCK markers in CI.
+#
+# Note on provenance. These versions come from resolving today's requirements,
+# not from the running production deployment, which could not be inspected. The
+# two may differ, since production has been installing unpinned packages since
+# it was first deployed. Verify on the Track B deployment before cutover.
+#
+# Direct dependencies are marked. Everything else is transitive.
+
+altair==6.2.2
+annotated-types==0.8.0
+anyio==4.14.2
+attrs==26.1.0
+blinker==1.9.0
+certifi==2026.7.22
+cffi==2.1.1
+charset-normalizer==3.4.9
+click==8.4.2
+cryptography==50.0.0
+distro==1.9.0
+google-auth-oauthlib==1.4.0
+google-auth==2.56.3  # direct
+groq==1.6.0  # direct
+gspread==6.2.1  # direct
+h11==0.16.0
+httpcore==1.0.9
+httptools==0.8.0
+httpx==0.28.1
+idna==3.18
+itsdangerous==2.2.0
+Jinja2==3.1.6
+jsonschema-specifications==2025.9.1
+jsonschema==4.26.0
+MarkupSafe==3.0.3
+narwhals==2.24.0
+numpy==2.4.6
+oauthlib==3.3.1
+packaging==26.3
+pandas==3.0.5
+pillow==12.3.0
+protobuf==7.35.1
+pyarrow==24.0.0
+pyasn1==0.6.4
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+pydeck==0.9.3
+python-dateutil==2.9.0.post0  # direct
+python-dotenv==1.2.2  # direct
+python-multipart==0.0.32
+pytz==2026.3.post1  # direct
+referencing==0.37.0
+reportlab==5.0.0  # direct
+requests-oauthlib==2.0.0
+requests==2.34.2
+rpds-py==2026.6.3
+six==1.17.0
+sniffio==1.3.1
+starlette==1.3.1
+streamlit==1.61.1  # direct
+tenacity==9.1.4
+toml==0.10.2
+typing-inspection==0.4.3
+typing_extensions==4.16.0
+urllib3==2.7.0
+uvicorn==0.52.1
+watchdog==6.0.0
+websockets==16.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,21 +12,25 @@
 # the lockfile.
 
 # Core framework
-streamlit
+streamlit==1.61.1
 
 # LLM API. Replaced by an OpenAI-compatible client in Phase 3 of the MSI
 # migration, which allows the same code to talk to Groq or a self-hosted vLLM
 # endpoint. See docs/MIGRATION_PLAN.md.
-groq
+groq==1.6.0
 
 # PDF generation
-reportlab
+reportlab==5.0.0
 
 # Utilities
-pytz
-python-dotenv
-python-dateutil
+pytz==2026.3.post1
+python-dotenv==1.2.2
+python-dateutil==2.9.0.post0
 
-# Google Sheets integration (secret code portal)
-gspread
-google-auth
+# Google Sheets integration (secret code portal).
+#
+# gspread is version-sensitive: utils/access_control.py branches on
+# hasattr(gspread, "service_account_from_dict"), which exists from gspread 5.0
+# and falls back to gspread.authorize below that.
+gspread==6.2.1
+google-auth==2.56.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,23 @@
+# Runtime dependencies.
+#
+# Every package here is imported by application code. Development and test-only
+# packages live in requirements-dev.txt.
+#
+# Versions are pinned and a resolved lockfile is provided in requirements.lock.
+# Install from the lockfile for a reproducible environment:
+#
+#     pip install -r requirements.lock
+#
+# Use this file when you intend to pick up compatible updates, then regenerate
+# the lockfile.
+
 # Core framework
 streamlit
 
-# LLM API
+# LLM API. Replaced by an OpenAI-compatible client in Phase 3 of the MSI
+# migration, which allows the same code to talk to Groq or a self-hosted vLLM
+# endpoint. See docs/MIGRATION_PLAN.md.
 groq
-
-# RAG and embeddings
-sentence-transformers
-faiss-cpu
-numpy
 
 # PDF generation
 reportlab
@@ -17,13 +27,6 @@ pytz
 python-dotenv
 python-dateutil
 
-# Google Sheets integration (for secret code portal)
+# Google Sheets integration (secret code portal)
 gspread
 google-auth
-google-auth-oauthlib
-
-# Deep learning backend (required by sentence-transformers)
-torch>=2.5.1
-
-# Speech features (Text-to-Speech fallback)
-gTTS>=2.3.0

--- a/secret_code_portal.py
+++ b/secret_code_portal.py
@@ -33,17 +33,9 @@ Requirements:
     - Internet connection for Google Sheets API calls
 """
 
+import logging
 import os
 
-# Suppress transformers library warnings BEFORE any imports touch it.
-# The transformers package (pulled in by sentence-transformers) tries to load
-# hundreds of vision model sub-modules that require torchvision (not installed),
-# producing thousands of ModuleNotFoundError tracebacks on every app startup.
-os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
-os.environ.setdefault("TRANSFORMERS_NO_ADVISORY_WARNINGS", "1")
-os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
-
-import logging
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
 


### PR DESCRIPTION
## Plan reference

`docs/MIGRATION_PLAN.md` section 7. Prerequisite for Phase 8 (containerization): building an image before pruning produces a roughly 6 GB image with CUDA layers that is then discarded.

## What changed

### Removed, all verified imported nowhere

`torch>=2.5.1`, `sentence-transformers`, `faiss-cpu`, `numpy`

These supported a RAG pipeline that no longer exists. PR #117 removed the last vestige, `_load_rubric_text`, which read rubric text and immediately discarded it.

**Plus one the plan did not identify:** `google-auth-oauthlib`. Nothing imports it and there is no interactive OAuth flow, since credentials are service-account based and need only `google-auth`. It stays available transitively through `gspread`, so this drops a direct declaration rather than a package.

### Moved to `requirements-dev.txt`

`gTTS`, imported only by `speech_text/tts_handler.py`, which in turn is imported only by tests. Voice mode is a documented dormant feature. This also drops an outbound dependency on `translate.google.com`, which matters because MSI compute-node internet access is restricted.

### Runtime set is now nine packages

Each confirmed imported by application code: `streamlit`, `groq`, `reportlab`, `pytz`, `python-dotenv`, `python-dateutil`, `gspread`, `google-auth`.

### Knock-on cleanups

- `.streamlit/config.toml` `folderWatchBlacklist` reduced to `reportlab`. The other entries existed solely to suppress roughly 4,000 `ModuleNotFoundError` tracebacks at startup from `transformers` importing vision sub-modules.
- The matching `TRANSFORMERS_VERBOSITY` / `TOKENIZERS_PARALLELISM` suppression at the top of `secret_code_portal.py`.

## A bug I introduced and caught

Removing that suppression block also removed the `import os` that line 728 still depends on. That would have been a **NameError at runtime**, and the test suite could not have caught it: `secret_code_portal` is a Streamlit script the suite never imports.

The import is restored, and I added **pyflakes** to CI. It catches undefined and unused names without executing anything, which is exactly the failure mode dependency pruning creates. Worth having permanently rather than just fixing the one instance.

## Impact

| | Before | After |
|---|---|---|
| Runtime packages declared | 14 | 8 |
| Approximate install size | ~6 GB (CUDA wheels) | ~400 MB |
| Outbound deps at runtime | + `huggingface.co`, `translate.google.com` | neither |

Removing `huggingface.co` retires one of the open MSI Help Desk questions.

## Still to come on this branch

Pinning and `requirements.lock`. No Python interpreter is available on the authoring machine, so resolved versions must be captured from a clean CI install rather than guessed. CI now prints `pip freeze` for that purpose.

## Merge gates

| Gate | Status |
|---|---|
| CI | Pending. Target zero failures |
| Production untouched | Targets `msi-hybrid`, never `main` |
| Plan reference | Section 7, above |
| Changelog | Added with the pin commit |
| Ordering | No prerequisites. Blocks Phase 8 |

## Rollback

Revert the commit. Nothing in application logic changed beyond restoring an import and deleting dead suppression code.