### PR TITLE
Phase 4: retire the per-student API key

### DIFF
--- a/docs/CHANGELOG_MIGRATION.md
+++ b/docs/CHANGELOG_MIGRATION.md
@@ -117,6 +117,92 @@ something again.
 
 ---
 
+## Phase 4: retire the per-student API key
+
+Date: 2026-08-11
+Branch: `msi/phase-4-api-keys`
+Pull request: #123
+Plan reference: `MIGRATION_PLAN.md` section 9
+Result: **254 passed, 2 skipped, 0 failed.**
+
+### Purpose
+
+Move the LLM credential from each student to the operator, read from the
+environment by `llm_provider`, in preparation for a single shared MSI endpoint.
+
+### This closed a real defect
+
+The key was held in Streamlit session state and then written to `os.environ`,
+which is process-global and shared by every concurrent session. Two students
+active at the same time could clobber each other's keys, so one student's
+requests could be billed to another student's account, and which one won was
+nondeterministic.
+
+PR #117 had already removed the read side of that race, by passing the key to
+the client explicitly instead of reading it back from the environment. This
+phase removed the write side, and the concept.
+
+### Removed
+
+- The API key field, its validation branch, the session-state store and the
+  `os.environ` write in `secret_code_portal.py`
+- The now-unused `import os` there
+- A pre-existing unused `import os` in `pages/developer_page.py`, which pyflakes
+  had been reporting as advisory since Phase 2
+
+### Changed
+
+| Item | Change |
+|---|---|
+| `mi_session._auth_guard` | Requires `student_name` only |
+| `pages/developer_page.py` guard | Same |
+| Auth error message | No longer tells students to re-enter a key they never supplied. Points at the instructor, logs the detail for the operator |
+| `run_practice_session` | Calls `load_settings()` with no argument, so the credential comes from `MI_LLM_API_KEY` |
+| `tests/test_flow_simulation.py` | Narrated the old credential flow; now describes the operator-held one |
+
+Reducing the guards mattered more than it looks. Leaving `groq_api_key` in the
+condition would have bounced **every** student back to the portal, because
+nothing populates that session key any more.
+
+### Added
+
+`tests/test_no_per_student_api_key.py`. The load-bearing test walks the AST of
+every request-path module asserting there is no assignment into `os.environ`,
+because the environment write is the actual defect rather than the input field.
+A grep for the field name alone would not catch someone reintroducing the write
+under a different name.
+
+### One test inverted
+
+`test_portal_credentials` asserted the portal **has** a Groq API key input. That
+requirement no longer exists, so the assertion was inverted and the test renamed
+to `test_portal_collects_only_the_student_name`, with a docstring explaining why,
+so a future reader does not "fix" it by restoring the field and the race with it.
+
+CI caught this on the first run. Against the old 17-failure baseline it would
+have been lost in the noise, which is the argument for the zero-failure gate in
+practice rather than in principle.
+
+### Deliberately not touched
+
+`config_loader.get_groq_api_key()` and its tests remain. It is dead code with no
+callers that reads only environment variables, so it is harmless. Removing it
+means removing its tests, which is outside this phase.
+
+### Rollback
+
+Operator-level: point `MI_LLM_BASE_URL` at Groq and set `MI_LLM_API_KEY` to one
+operator key. Per the approved decision there is no per-student fallback path,
+which is deliberate, since that path is the race.
+
+### Coordination required at cutover, not before
+
+This changes the student-facing form. Onboarding instructions telling students
+to obtain their own Groq key must be updated at cutover. Production still runs
+the old flow, so those instructions remain correct until then.
+
+---
+
 ## Phase 3: LLM provider abstraction
 
 Date: 2026-08-11

--- a/docs/MIGRATION_TRACKER.md
+++ b/docs/MIGRATION_TRACKER.md
@@ -94,8 +94,8 @@ Legend: Done, In progress, Blocked, Not started.
 | 1a | Clear the 17 stale test failures | `msi/phase-1a-stale-tests` | #118 | **Done** 2026-08-11 | Merged. CI green |
 | - | Integrate PR #117 from main | `msi-hybrid` direct | #117 | **Done** 2026-08-11 | Merged + semantic fix. CI green, 228 passed |
 | 2 | Dependency prune, pin, lock | `msi/phase-2-deps` | #121 | **Done** 2026-08-11 | Merged. CI green |
-| 3 | LLM provider abstraction | `msi/phase-3-llm-provider` | #122 | **In review** 2026-08-11 | CI green, 250 passed, zero test edits |
-| 4 | Retire per-student API keys | `msi/phase-4-api-keys` | not opened | Not started | After Phase 3. PR #117 now merged, overlap resolved |
+| 3 | LLM provider abstraction | `msi/phase-3-llm-provider` | #122 | **Done** 2026-08-11 | Merged. CI green |
+| 4 | Retire per-student API keys | `msi/phase-4-api-keys` | #123 | **In review** 2026-08-11 | CI green, 254 passed |
 | 5 | Path externalization | `msi/phase-5-paths` | not opened | Not started | Blocks Phase 8 |
 | 6 | FERPA de-identification boundary | `msi/phase-6-deident` | not opened | Not started | **Blocked** on the A1 FERPA answer. Blocks Phase 7 |
 | 7 | Data persistence: Box archiving and MSI store | `msi/phase-7-persistence` | not opened | Not started | After Phase 6. Needs A3 answer for the MSI half |

--- a/mi_session.py
+++ b/mi_session.py
@@ -173,8 +173,8 @@ def _auth_guard(expected_bot: str) -> None:
             st.switch_page("secret_code_portal.py")
         st.stop()
 
-    if "groq_api_key" not in st.session_state or "student_name" not in st.session_state:
-        st.error(":warning: Session Error: Missing credentials.")
+    if "student_name" not in st.session_state:
+        st.error(":warning: Session Error: Missing student name.")
         if st.button("Return to Portal"):
             st.switch_page("secret_code_portal.py")
         st.stop()
@@ -261,7 +261,14 @@ def _handle_chat_turn(
         assistant_text = response.choices[0].message.content or ""
     except Exception as exc:
         if is_auth_error(exc):
-            st.error("Invalid API key. Re-enter your Groq key on the portal and reload.")
+            # The credential is now operator-held, so there is nothing a
+            # student can do about this. Direct them to their instructor and
+            # log the detail for whoever maintains the deployment.
+            logger.error("LLM authentication failed: %s", exc)
+            st.error(
+                "The practice service is currently unavailable. "
+                "Please contact your instructor."
+            )
             return
         raise
 
@@ -395,14 +402,11 @@ def run_practice_session(config: SessionConfig) -> None:
     st.title(f"{config.page_icon} {config.page_title}")
     st.markdown(config.intro_markdown, unsafe_allow_html=True)
 
-    # Resolve the LLM endpoint. Defaults reproduce the previous Groq behaviour,
-    # so an unconfigured deployment is unchanged; pointing MI_LLM_BASE_URL at a
-    # self-hosted vLLM server switches provider with no code change.
-    #
-    # The student's key is passed explicitly and wins over the environment,
-    # preserving today's per-student credential model. When the shared endpoint
-    # replaces per-student keys, this argument simply goes away.
-    settings = load_settings(api_key=st.session_state.groq_api_key)
+    # Resolve the LLM endpoint. The credential is operator-held, supplied
+    # through MI_LLM_API_KEY rather than by each student, which removes the
+    # cross-user race that the per-student model had. Pointing MI_LLM_BASE_URL
+    # at a self-hosted vLLM server switches provider with no code change.
+    settings = load_settings()
     client = make_client(settings)
 
     _initialize_state(config)

--- a/pages/developer_page.py
+++ b/pages/developer_page.py
@@ -14,10 +14,9 @@ Usage:
 
 Requirements:
     - Authentication via secret code portal with DEVELOPER role
-    - Groq API key and student name from session state
+    - Student name in session state
 """
 
-import os
 import logging
 import streamlit as st
 
@@ -66,8 +65,8 @@ if user_role not in (ROLE_DEVELOPER, ROLE_INSTRUCTOR):
     st.stop()
 
 # Check if credentials are available
-if 'groq_api_key' not in st.session_state or 'student_name' not in st.session_state:
-    st.error("⚠️ Session Error: Missing credentials.")
+if 'student_name' not in st.session_state:
+    st.error("⚠️ Session Error: Missing student name.")
     st.info("Please go back to the portal and re-enter your information.")
     if st.button("← Return to Portal"):
         st.switch_page("secret_code_portal.py")

--- a/secret_code_portal.py
+++ b/secret_code_portal.py
@@ -34,7 +34,6 @@ Requirements:
 """
 
 import logging
-import os
 
 import streamlit as st
 from streamlit.errors import StreamlitAPIException
@@ -577,7 +576,7 @@ def main():
         Enter the secret code provided by your instructor to access your assigned chatbot practice session.
         
         **Instructions:**
-        1. Enter your name and Groq API key
+        1. Enter your name
         2. Enter your secret code
         3. Click "Submit Code" to verify your access
         4. You will be redirected to your assigned chatbot (OHI, HPV, Tobacco, or Perio)
@@ -684,14 +683,6 @@ def main():
                 help="Your name for the feedback report"
             )
             
-            # Groq API key input
-            groq_api_key = st.text_input(
-                "🔑 Groq API Key",
-                type="password",
-                placeholder="Enter your Groq API key",
-                help="Your Groq API key for accessing the chatbot. Get one at https://console.groq.com/"
-            )
-            
             # Secret code input
             secret_code = st.text_input(
                 "🎫 Secret Code",
@@ -706,8 +697,6 @@ def main():
                 # Validate all inputs
                 if not student_name:
                     st.error("Please enter your name.")
-                elif not groq_api_key:
-                    st.error("Please enter your Groq API key.")
                 elif not secret_code:
                     st.error("Please enter a secret code.")
                 else:
@@ -723,12 +712,8 @@ def main():
                                 'role': result.get('role', ROLE_STUDENT)
                             }
                             st.session_state.student_name = student_name
-                            st.session_state.groq_api_key = groq_api_key
                             st.session_state.user_role = result.get('role', ROLE_STUDENT)
-                            
-                            # Set environment variable for libraries that need it
-                            os.environ["GROQ_API_KEY"] = groq_api_key
-                            
+
                             st.success(result['message'])
                             
                             # Handle Instructor role with access to all bots

--- a/tests/test_flow_simulation.py
+++ b/tests/test_flow_simulation.py
@@ -19,17 +19,15 @@ def simulate_portal_entry():
     
     # Simulated user inputs
     student_name = "John Doe"
-    groq_api_key = "gsk_test_key_123"
     secret_code = "ABC123"
-    
+
     print(f"\nStudent enters:")
     print(f"  - Name: {student_name}")
-    print(f"  - API Key: {groq_api_key[:10]}... (hidden)")
     print(f"  - Secret Code: {secret_code}")
-    
+    print(f"\nNo API key is requested. The LLM credential is operator-held.")
+
     return {
         "student_name": student_name,
-        "groq_api_key": groq_api_key,
         "secret_code": secret_code
     }
 
@@ -85,8 +83,7 @@ def simulate_session_state_setup(credentials, validation_result):
             "bot": validation_result["bot"],
             "name": validation_result["name"]
         },
-        "student_name": credentials["student_name"],
-        "groq_api_key": credentials["groq_api_key"]
+        "student_name": credentials["student_name"]
     }
     
     print("\nSession state configured:")
@@ -94,10 +91,8 @@ def simulate_session_state_setup(credentials, validation_result):
     print(f"  ✓ redirect_info.bot: {session_state['redirect_info']['bot']}")
     print(f"  ✓ redirect_info.name: {session_state['redirect_info']['name']}")
     print(f"  ✓ student_name: {session_state['student_name']}")
-    print(f"  ✓ groq_api_key: ***hidden***")
-    
-    print(f"\n✓ Environment variable set: GROQ_API_KEY")
-    
+    print(f"\n✓ No API key in session state, and no process-global env write")
+
     return session_state
 
 
@@ -140,11 +135,12 @@ def simulate_bot_page_guard(session_state, expected_bot):
         return False
     print(f"  ✓ User authorized for {expected_bot} bot")
     
-    # Check 3: Credentials present
-    if 'groq_api_key' not in session_state or 'student_name' not in session_state:
-        print(f"  ✗ Missing credentials - redirecting to portal")
+    # Check 3: Student name present. The LLM credential is no longer part of
+    # session state, so it is not checked here.
+    if 'student_name' not in session_state:
+        print(f"  ✗ Missing student name - redirecting to portal")
         return False
-    print(f"  ✓ Credentials available in session state")
+    print(f"  ✓ Student name available in session state")
     
     print(f"\n✓ All checks passed - granting access to bot")
     return True
@@ -156,16 +152,19 @@ def simulate_bot_usage(session_state):
     print("STEP 6: Bot uses centralized credentials")
     print("="*60)
     
-    print(f"\nBot retrieves credentials from session state:")
-    print(f"  api_key = st.session_state.groq_api_key")
+    print(f"\nBot retrieves the student name from session state:")
     print(f"  student_name = st.session_state.student_name")
-    
+
+    print(f"\nThe LLM endpoint and credential come from the environment:")
+    print(f"  settings = load_settings()   # MI_LLM_BASE_URL, MI_LLM_API_KEY")
+    print(f"  client = make_client(settings)")
+
     print(f"\n✓ No API key input field shown to student")
     print(f"✓ No student name input field shown to student")
     print(f"✓ Student proceeds directly to conversation")
-    
+
     print(f"\nBot functionality:")
-    print(f"  - Initializes Groq client with centralized API key")
+    print(f"  - Uses one operator-held credential, not a per-student key")
     print(f"  - Uses student name for feedback report")
     print(f"  - Maintains secure session throughout conversation")
 

--- a/tests/test_multipage_integration.py
+++ b/tests/test_multipage_integration.py
@@ -170,30 +170,34 @@ def test_auth_guard_performs_its_checks():
     print("  OK shared auth guard enforces authentication")
 
 
-def test_portal_credentials():
-    """Test that portal has credential inputs."""
+def test_portal_collects_only_the_student_name():
+    """The portal collects a name and a code, and no LLM credential.
+
+    This assertion was inverted deliberately. It previously required the portal
+    to have a Groq API key input. That field was removed because the key was
+    written to os.environ, a process-global mapping shared by every concurrent
+    Streamlit session, so two students active at once could clobber each other's
+    keys. The credential is now operator-held. See
+    tests/test_no_per_student_api_key.py for the guard on the underlying defect.
+    """
     print("\nTesting portal credential inputs...")
-    
+
     with open('secret_code_portal.py', 'r', encoding='utf-8') as f:
         content = f.read()
-    
-    # Check for credential inputs
+
     assert 'Student Name' in content or 'student_name' in content, \
         "Portal should have student name input"
-    assert 'Groq API Key' in content or 'groq_api_key' in content, \
-        "Portal should have Groq API key input"
-    
-    # Check that credentials are stored in session state
     assert 'st.session_state.student_name' in content, \
         "Portal should store student name in session state"
-    assert 'st.session_state.groq_api_key' in content, \
-        "Portal should store API key in session state"
-    
+
+    assert 'groq_api_key' not in content, \
+        "Portal must not collect or store a per-student API key"
+
     # Check for internal navigation
     assert 'st.switch_page' in content, \
         "Portal should use st.switch_page for internal navigation"
-    
-    print("✓ Portal has proper credential inputs and navigation")
+
+    print("OK Portal collects only the student name, and navigates internally")
 
 
 def test_caching_decorators():

--- a/tests/test_no_per_student_api_key.py
+++ b/tests/test_no_per_student_api_key.py
@@ -1,0 +1,100 @@
+"""Guards the removal of the per-student LLM credential.
+
+Before this change each student pasted their own Groq API key into the portal.
+It was stored in Streamlit session state and then written to ``os.environ``,
+which is process-global and shared by every concurrent session. Two students
+active at once could clobber each other's keys, so one student's requests could
+be billed to another student's account, nondeterministically.
+
+The credential is now operator-held and read from the environment by
+``llm_provider.load_settings``. These tests assert the old path cannot come
+back by accident, since reintroducing it would restore a real cross-user defect
+rather than merely undoing a refactor.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Modules that run in a request path, where a process-global write would be
+# visible to other concurrent users.
+REQUEST_PATH_MODULES = (
+    "secret_code_portal.py",
+    "mi_session.py",
+    "pages/developer_page.py",
+    "pages/OHI.py",
+    "pages/HPV.py",
+    "pages/Perio.py",
+    "pages/Tobacco.py",
+)
+
+
+def _source(relative_path):
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_no_module_reads_a_per_student_key_from_session_state():
+    """``st.session_state.groq_api_key`` must not reappear."""
+    for module in REQUEST_PATH_MODULES:
+        source = _source(module)
+        assert "groq_api_key" not in source, (
+            f"{module} references groq_api_key. The LLM credential is "
+            f"operator-held; read it through llm_provider.load_settings()."
+        )
+
+
+def test_no_module_writes_the_environment_in_a_request_path():
+    """No ``os.environ[...] = ...`` assignment in any request-path module.
+
+    This is the actual defect, not the key field itself. A per-request write to
+    a process-global mapping races across concurrent Streamlit sessions.
+    """
+    for module in REQUEST_PATH_MODULES:
+        tree = ast.parse(_source(module))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not isinstance(target, ast.Subscript):
+                    continue
+                value = target.value
+                is_environ = (
+                    isinstance(value, ast.Attribute)
+                    and value.attr == "environ"
+                ) or (isinstance(value, ast.Name) and value.id == "environ")
+                assert not is_environ, (
+                    f"{module} line {node.lineno} assigns into os.environ. "
+                    f"That is process-global and races across concurrent "
+                    f"users; pass configuration explicitly instead."
+                )
+
+
+def test_portal_does_not_ask_students_for_an_api_key():
+    source = _source("secret_code_portal.py")
+    lowered = source.lower()
+    assert "api key" not in lowered, (
+        "The portal must not prompt for an API key. The credential is "
+        "supplied by the operator through MI_LLM_API_KEY."
+    )
+    assert "console.groq.com" not in lowered, (
+        "The portal must not direct students to obtain their own key."
+    )
+
+
+def test_auth_guards_require_only_the_student_name():
+    """The guards must not gate on a credential that no longer exists.
+
+    If they did, every student would be bounced back to the portal, because
+    nothing populates that session key any more.
+    """
+    for module in ("mi_session.py", "pages/developer_page.py"):
+        source = _source(module)
+        assert "student_name" in source, f"{module} should still require student_name"
+        assert "groq_api_key" not in source, (
+            f"{module} still gates on groq_api_key, which is never set now"
+        )


### PR DESCRIPTION
## Plan reference

`docs/MIGRATION_PLAN.md` section 9. The LLM credential becomes operator-held, read from the environment by `llm_provider`, rather than pasted into the portal by each student.

## This closes a real defect, not just a refactor

The key was stored in Streamlit session state and then written to `os.environ`, which is **process-global and shared by every concurrent session**. Two students active at once could clobber each other's keys, so one student's requests could be billed to another student's account, nondeterministically.

PR #117 removed the *read* side of that race by passing the key to the client explicitly. This removes the *write* side, and the concept entirely.

## Changed

**Removed** the API key field, its validation branch, the session-state store and the `os.environ` write from `secret_code_portal.py`, plus the now-unused `import os` there and a pre-existing unused one in `pages/developer_page.py` that pyflakes had been reporting.

**Guards now require `student_name` only.** This matters: leaving `groq_api_key` in the guard would have bounced *every* student back to the portal, since nothing populates that key any more.

**The auth error message changed.** It no longer tells students to re-enter a key they never supplied:

```
The practice service is currently unavailable. Please contact your instructor.
```

The underlying error is logged for whoever runs the deployment.

**`tests/test_flow_simulation.py`** narrated the old credential flow and now describes the operator-held one.

## New guard

`tests/test_no_per_student_api_key.py`. The load-bearing test walks the **AST of every request-path module** asserting there is no assignment into `os.environ`, because the environment write is the actual defect rather than the input field. A grep for the field name alone would not catch someone reintroducing the write under a different name.

Reintroducing either would restore a live cross-user bug, so it earns a permanent guard rather than a comment.

## Deliberately not touched

`config_loader.get_groq_api_key()` remains, with its tests. It is dead code with no callers and reads only environment variables, so it is harmless. Removing it means removing its tests, which is outside this phase. Recorded rather than silently expanded into.

## Rollback

Operator-level: point `MI_LLM_BASE_URL` at Groq and set `MI_LLM_API_KEY` to one operator key. Per the approved decision there is no per-student fallback path, which is deliberate: that path is the race.

## Coordination needed before cutover, not now

This changes the student-facing form. Any onboarding instructions telling students to obtain a Groq key must be updated **at cutover**. Production still uses the old flow, so those instructions remain correct until then.

## Merge gates

| Gate | Status |
|---|---|
| CI | Pending |
| Production untouched | Targets `msi-hybrid` |
| Plan reference | Section 9 |
| Ordering | After Phase 3, which this depends on |