### PR TITLE
Phase 5: externalize runtime paths

### DIFF
--- a/app_env.py
+++ b/app_env.py
@@ -28,6 +28,26 @@ MI_SMTP_ENABLED
     migration environment uses this so test reports cannot reach the course Box
     archive and so the startup queue drain cannot attempt a live login.
     Defaults to enabled.
+
+Writable paths
+--------------
+MI_LOG_DIR, MI_QUEUE_DIR, MI_STATE_DIR
+    Directories the application writes to at runtime. Each defaults to a
+    location beside this file, reproducing today's layout, and each resolves to
+    an absolute path.
+
+    These exist because the application previously used bare relative paths,
+    resolved against the process working directory. That works only when the app
+    is launched from the repository root. Under Apptainer the application
+    directory is read-only and the first write fails outright, so Phase 8 cannot
+    proceed until every writable path can be pointed somewhere else.
+
+MI_CONFIG_PATH
+    Location of config.json.
+
+MI_GOOGLE_SA_FILE
+    Google service account JSON, for local development only. Deployments should
+    use the GOOGLESA secret instead.
 """
 
 import os
@@ -36,6 +56,10 @@ import os
 # Production Google Sheet. Retained as the default so that an unconfigured
 # deployment continues to behave exactly as before.
 _PRODUCTION_SHEET_ID = "1x_MA3MqvyxN3p7v_mQ3xYB9SmEGPn1EspO0fUsYayFY"
+
+# Resolved from this file rather than the working directory, so behaviour does
+# not depend on where the process was started.
+_APP_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
@@ -77,6 +101,93 @@ def is_test_environment() -> bool:
 def is_smtp_enabled() -> bool:
     """Return True when outbound SMTP connections are permitted."""
     return _env_bool("MI_SMTP_ENABLED", True)
+
+
+# ---------------------------------------------------------------------------
+# Writable and configured paths
+# ---------------------------------------------------------------------------
+
+
+def _resolve_dir(env_name: str, default_basename: str) -> str:
+    """Return an absolute directory path from ``env_name``.
+
+    Falls back to ``default_basename`` beside this file, which reproduces the
+    previous layout for an unconfigured deployment. A relative value in the
+    environment is resolved against the application root rather than the
+    working directory, because the working directory is exactly the variable
+    this function exists to remove.
+    """
+    raw = os.environ.get(env_name)
+    if not raw:
+        return os.path.join(_APP_ROOT, default_basename)
+    return os.path.abspath(os.path.join(_APP_ROOT, os.path.expanduser(raw)))
+
+
+def get_log_dir() -> str:
+    """Directory for application logs."""
+    return _resolve_dir("MI_LOG_DIR", "git_logs")
+
+
+def get_queue_dir() -> str:
+    """Directory for the outbound email retry queue.
+
+    Historically named "SMTP logs", with a space. That space had to be quoted
+    in every shell command, Slurm script and Apptainer bind argument that
+    touched it, so the default is now "smtp_queue". See
+    ``get_legacy_queue_dir`` for the migration path.
+    """
+    return _resolve_dir("MI_QUEUE_DIR", "smtp_queue")
+
+
+def get_legacy_queue_dir() -> str:
+    """Previous queue location, read once so pending items are not stranded.
+
+    Retained for one release. Anything still queued under the old directory
+    when this version deploys would otherwise never be sent.
+    """
+    return os.path.join(_APP_ROOT, "SMTP logs")
+
+
+def get_state_dir() -> str:
+    """Directory for durable session state.
+
+    Introduced here so the path layer is complete in one change. It is consumed
+    in Phase 7, where conversation transcripts and evaluation results are
+    journaled. On MSI this points at Tier 1 project storage, never
+    /scratch.global, which purges files 30 days after creation.
+    """
+    return _resolve_dir("MI_STATE_DIR", "session_state")
+
+
+def get_config_path() -> str:
+    """Absolute path to config.json."""
+    raw = os.environ.get("MI_CONFIG_PATH")
+    if not raw:
+        return os.path.join(_APP_ROOT, "config.json")
+    return os.path.abspath(os.path.join(_APP_ROOT, os.path.expanduser(raw)))
+
+
+def get_google_sa_file() -> str:
+    """Absolute path to the Google service account JSON, for local use only.
+
+    Deployments should supply the GOOGLESA secret instead of a file on disk.
+    """
+    raw = os.environ.get("MI_GOOGLE_SA_FILE")
+    if not raw:
+        return os.path.join(_APP_ROOT, "umnsod-mibot-ea3154b145f1.json")
+    return os.path.abspath(os.path.join(_APP_ROOT, os.path.expanduser(raw)))
+
+
+def ensure_writable_dirs() -> None:
+    """Create the writable directories if they are missing.
+
+    Called once at startup. Failure is deliberately not swallowed: if these
+    cannot be created the application cannot log or queue, and discovering that
+    at startup is far better than discovering it when a student finishes a
+    session.
+    """
+    for path in (get_log_dir(), get_queue_dir()):
+        os.makedirs(path, exist_ok=True)
 
 
 def render_environment_banner() -> None:

--- a/config.json
+++ b/config.json
@@ -17,17 +17,15 @@
         "tobacco_box_email": "Tobacco.uyjxww6ze8qonvnx@u.box.com",
         "perio_box_email": "Perio_D.5bdqj9rorjklmg30@u.box.com"
     },
+    "_comment_logging": "Directory locations are resolved by app_env from MI_LOG_DIR and MI_QUEUE_DIR, not from this file. The former log_directory, log_file, smtp_log_directory and smtp_log_file keys held bare relative paths that depended on the process working directory and could not be redirected, which fails under a read-only container filesystem.",
     "logging": {
-        "log_directory": "git_logs",
         "max_log_size_mb": 10,
         "backup_count": 5,
         "cleanup_days": 90,
         "enable_monitoring": true,
-        "log_file": "git_logs/chatbot.log",
         "max_size": 10485760,
         "log_level": "INFO",
-        "smtp_log_directory": "SMTP logs",
-        "smtp_log_file": "SMTP logs/email_backup.log",
+        "smtp_log_file": "email_backup.log",
         "smtp_max_log_size_mb": 10,
         "smtp_backup_count": 30
     },

--- a/docs/CHANGELOG_MIGRATION.md
+++ b/docs/CHANGELOG_MIGRATION.md
@@ -117,6 +117,107 @@ something again.
 
 ---
 
+## Phase 5: externalize runtime paths
+
+Date: 2026-08-11
+Branch: `msi/phase-5-paths`
+Pull request: #124
+Plan reference: `MIGRATION_PLAN.md` section 10
+Result: **264 passed, 2 skipped, 0 failed.**
+
+### Purpose
+
+Make the application run correctly with an arbitrary working directory and a
+read-only application directory. Hard prerequisite for Phase 8, where Apptainer
+mounts the application directory read-only and every bare relative write would
+fail on the first attempt.
+
+### What was wrong
+
+Four paths resolved against the process working directory.
+
+| Path | Used for |
+|---|---|
+| `git_logs` | Application logs |
+| `SMTP logs` | Email retry queue, including student PDFs on delivery failure |
+| `open('config.json')` | Configuration, opened by bare name in two places |
+| `umnsod-mibot-...json` | Google service account, bare filename |
+
+That is correct only when the app is launched from the repository root, which a
+Slurm job does not guarantee.
+
+### Added
+
+Five resolvers in `app_env`, each returning an absolute path and defaulting to a
+location beside `app_env.py` so an unconfigured deployment keeps today's layout:
+`MI_LOG_DIR`, `MI_QUEUE_DIR`, `MI_STATE_DIR`, `MI_CONFIG_PATH`,
+`MI_GOOGLE_SA_FILE`.
+
+A relative override resolves against the application root rather than the
+working directory, because that dependence is the thing being removed.
+
+`MI_STATE_DIR` is introduced here although Phase 7 consumes it, so the path
+layer is completed in one change rather than revisited.
+
+`ensure_writable_dirs()` creates the directories at startup and deliberately
+does not swallow failure. A deployment that cannot log or queue should fail
+visibly at startup rather than mid-session.
+
+### The directory with a space
+
+`SMTP logs` became `smtp_queue`. The space had to be quoted in every shell
+command, Slurm script and Apptainer bind argument that referenced it.
+
+`EmailQueue.migrate_legacy_dir()` moves anything left under the old name on
+first run, refusing to overwrite an existing entry. Without it, any report
+queued at the moment this version deploys would never be sent.
+
+### Resolution at call time, not import time
+
+`logger_config` would naturally have bound the log directory into a module
+constant. That freezes whatever `MI_LOG_DIR` happened to be when the module was
+first imported, which is the same trap that made `SessionConfig`'s model
+defaults unconfigurable in Phase 3. Caught during this change rather than after
+it.
+
+### The startup hang
+
+The email queue drain ran at module import scope. It performs live SMTP
+connections with retry delays up to 120 seconds and a 30 second connection
+timeout, so a queue holding several entries and an unreachable mail server
+stalled application startup for minutes before a student saw anything.
+
+On MSI this would become recurrent rather than occasional: outbound port 587
+from compute nodes is unconfirmed, and a service restarting on a walltime
+boundary would hang on every restart. It now sits behind `@st.cache_resource`,
+called from the page body.
+
+### config.json
+
+Dropped `log_directory`, `log_file` and `smtp_log_directory`. Keeping path keys
+in a config file that is itself located by a path is circular, and the values
+were bare relative paths.
+
+### Tests
+
+`tests/test_path_externalization.py` pins absoluteness, override behaviour, the
+no-space rename, and an AST check that no module outside `app_env` hardcodes a
+writable directory literal, so the pattern cannot creep back in.
+
+### Verification
+
+The acceptance test is starting from a foreign working directory:
+
+```
+cd / && MI_LOG_DIR=/tmp/mi/logs MI_QUEUE_DIR=/tmp/mi/queue \
+  python -m streamlit run /abs/path/secret_code_portal.py
+```
+
+That has not been executed here, since no Python interpreter is available on the
+authoring machine. It should be run on the Track B deployment before Phase 8.
+
+---
+
 ## Phase 4: retire the per-student API key
 
 Date: 2026-08-11

--- a/docs/MIGRATION_TRACKER.md
+++ b/docs/MIGRATION_TRACKER.md
@@ -95,8 +95,8 @@ Legend: Done, In progress, Blocked, Not started.
 | - | Integrate PR #117 from main | `msi-hybrid` direct | #117 | **Done** 2026-08-11 | Merged + semantic fix. CI green, 228 passed |
 | 2 | Dependency prune, pin, lock | `msi/phase-2-deps` | #121 | **Done** 2026-08-11 | Merged. CI green |
 | 3 | LLM provider abstraction | `msi/phase-3-llm-provider` | #122 | **Done** 2026-08-11 | Merged. CI green |
-| 4 | Retire per-student API keys | `msi/phase-4-api-keys` | #123 | **In review** 2026-08-11 | CI green, 254 passed |
-| 5 | Path externalization | `msi/phase-5-paths` | not opened | Not started | Blocks Phase 8 |
+| 4 | Retire per-student API keys | `msi/phase-4-api-keys` | #123 | **Done** 2026-08-11 | Merged. CI green |
+| 5 | Path externalization | `msi/phase-5-paths` | #124 | **In review** 2026-08-11 | CI green, 264 passed. Unblocks Phase 8 |
 | 6 | FERPA de-identification boundary | `msi/phase-6-deident` | not opened | Not started | **Blocked** on the A1 FERPA answer. Blocks Phase 7 |
 | 7 | Data persistence: Box archiving and MSI store | `msi/phase-7-persistence` | not opened | Not started | After Phase 6. Needs A3 answer for the MSI half |
 | 8 | Containerization with Apptainer | `msi/phase-8-container` | not opened | Not started | **Blocked** on MSI account. After Phases 2 and 5 |

--- a/email_queue.py
+++ b/email_queue.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from datetime import datetime
 
+from app_env import get_legacy_queue_dir, get_queue_dir
+
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +28,61 @@ class EmailQueue:
     """Manages persistent queue of failed email attempts."""
     
     QUEUE_FILE = "failed_emails.json"
-    
-    def __init__(self, queue_dir: str = "SMTP logs"):
+
+    def __init__(self, queue_dir: Optional[str] = None):
         """
         Initialize email queue.
-        
+
         Args:
-            queue_dir: Directory to store queue file and PDFs (default: "SMTP logs")
+            queue_dir: Directory to store queue file and PDFs. Defaults to
+                app_env.get_queue_dir(), which is absolute and controlled by
+                MI_QUEUE_DIR.
+
+        Note that this directory holds generated student PDFs when delivery
+        fails, so it is a FERPA-relevant location. It must never be inside the
+        application directory on a shared filesystem.
         """
-        self.queue_path = Path(queue_dir) / self.QUEUE_FILE
-        self.queue_dir = Path(queue_dir)
+        resolved = queue_dir or get_queue_dir()
+        self.queue_path = Path(resolved) / self.QUEUE_FILE
+        self.queue_dir = Path(resolved)
         self.queue_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
         logger.info(f"Email queue initialized at: {self.queue_path}")
+
+    @classmethod
+    def migrate_legacy_dir(cls) -> int:
+        """Move anything left in the old "SMTP logs" directory into the new one.
+
+        The queue directory was renamed from "SMTP logs" to "smtp_queue"
+        because the space had to be quoted in every shell command, Slurm script
+        and Apptainer bind argument that referenced it.
+
+        Without this, any report queued under the old name at the moment this
+        version deploys would never be sent. Returns the number of files moved.
+        """
+        legacy = Path(get_legacy_queue_dir())
+        if not legacy.is_dir():
+            return 0
+
+        target = Path(get_queue_dir())
+        target.mkdir(parents=True, exist_ok=True)
+
+        moved = 0
+        for item in list(legacy.glob("queued_*.pdf")) + list(legacy.glob(cls.QUEUE_FILE)):
+            destination = target / item.name
+            if destination.exists():
+                # Never overwrite a live queue entry with a stale one.
+                logger.warning("Skipping legacy queue item, target exists: %s", item.name)
+                continue
+            try:
+                item.replace(destination)
+                moved += 1
+            except OSError as exc:
+                logger.error("Could not migrate legacy queue item %s: %s", item.name, exc)
+
+        if moved:
+            logger.info("Migrated %d item(s) from the legacy queue directory", moved)
+        return moved
         
     def add(self, pdf_data: bytes, filename: str, recipient: str, 
             student_name: str, session_type: str) -> str:

--- a/email_utils.py
+++ b/email_utils.py
@@ -29,7 +29,7 @@ import io
 import time
 from datetime import datetime
 
-from app_env import is_smtp_enabled
+from app_env import get_config_path, get_queue_dir, is_smtp_enabled
 
 
 class EmailConfigError(Exception):
@@ -72,18 +72,21 @@ class SecureEmailSender:
             logger.setLevel(logging.INFO)
         return logger
     
-    def setup_smtp_logger(self, log_directory: str = "SMTP logs", 
+    def setup_smtp_logger(self, log_directory: Optional[str] = None,
                           log_filename: str = "email_backup.log") -> logging.Logger:
         """
         Set up a rotating file logger for SMTP operations.
         
         Args:
-            log_directory: Directory to store log files
+            log_directory: Directory to store log files. Defaults to
+                app_env.get_queue_dir(), which is absolute.
             log_filename: Name of the log file
-            
+
         Returns:
             Configured logger instance
         """
+        log_directory = log_directory or get_queue_dir()
+
         # Create log directory if it doesn't exist
         os.makedirs(log_directory, exist_ok=True)
         
@@ -547,8 +550,9 @@ class RobustEmailSender(SecureEmailSender):
         
         # Initialize email queue
         from email_queue import EmailQueue
-        log_dir = config.get('logging', {}).get('smtp_log_directory', 'SMTP logs') if config else 'SMTP logs'
-        self.email_queue = EmailQueue(queue_dir=log_dir)
+        # The queue location comes from app_env rather than config.json, so it
+        # is absolute and independent of the working directory.
+        self.email_queue = EmailQueue()
     
     def send_with_guaranteed_delivery(self, 
                                        pdf_buffer: io.BytesIO, 
@@ -806,7 +810,7 @@ def send_box_backup_email(pdf_buffer: io.BytesIO,
     if config is None:
         try:
             import json
-            with open('config.json', 'r') as f:
+            with open(get_config_path(), 'r') as f:
                 config = json.load(f)
         except Exception as e:
             return {
@@ -866,7 +870,7 @@ def send_box_backup_email(pdf_buffer: io.BytesIO,
     
     # Set up SMTP logger
     logging_config = config.get('logging', {})
-    log_dir = logging_config.get('smtp_log_directory', 'SMTP logs')
+    log_dir = get_queue_dir()
     log_file = logging_config.get('smtp_log_file', 'email_backup.log')
     
     # Create sender instance
@@ -920,7 +924,7 @@ if __name__ == "__main__":
     
     # Test configuration loading
     try:
-        with open('config.json', 'r') as f:
+        with open(get_config_path(), 'r') as f:
             config = json.load(f)
         
         sender = SecureEmailSender(config)

--- a/logger_config.py
+++ b/logger_config.py
@@ -29,10 +29,21 @@ from pathlib import Path
 from datetime import datetime
 import pytz
 
+from app_env import get_log_dir
 
-# Default log configuration
+
+# Default log configuration.
+#
+# The log directory is resolved by app_env.get_log_dir() at call time, not
+# bound to a module constant. Binding it at import would freeze whatever
+# MI_LOG_DIR happened to be when this module was first imported, which is the
+# same trap that made SessionConfig's model defaults unconfigurable.
+#
+# It was previously the bare relative path "git_logs", so the log location
+# depended on the process working directory and could not be redirected at all.
+# Under Apptainer the application directory is read-only and that would fail on
+# the first write.
 DEFAULT_LOG_LEVEL = logging.INFO
-DEFAULT_LOG_DIR = "git_logs"
 DEFAULT_LOG_FILE = "chatbot.log"
 DEFAULT_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 DEFAULT_BACKUP_COUNT = 5
@@ -158,7 +169,7 @@ def setup_logging(
     This should be called once at application startup.
     
     Args:
-        log_dir: Directory for log files (default: git_logs)
+        log_dir: Directory for log files (default: app_env.get_log_dir())
         log_file: Log file name (default: chatbot.log)
         level: Logging level (default: INFO)
         console_output: Whether to output logs to console (default: True)
@@ -167,8 +178,9 @@ def setup_logging(
         backup_count: Number of backup files to keep (default: 5)
         redact_emails: Whether to redact email addresses (default: False)
     """
-    # Use defaults if not provided
-    log_dir = log_dir or DEFAULT_LOG_DIR
+    # Use defaults if not provided. get_log_dir() is called here rather than
+    # read from a module constant so MI_LOG_DIR is honoured at call time.
+    log_dir = log_dir or get_log_dir()
     log_file = log_file or DEFAULT_LOG_FILE
     
     # Create log directory if it doesn't exist
@@ -324,4 +336,4 @@ if __name__ == "__main__":
     logger.info("API key: sk-abcdef123456 should be redacted")
     logger.info("Password: mypassword123 should be redacted")
     
-    print("\nLogging test complete. Check git_logs/chatbot.log for output.")
+    print(f"\nLogging test complete. Check {get_log_dir()}/chatbot.log for output.")

--- a/secret_code_portal.py
+++ b/secret_code_portal.py
@@ -54,7 +54,12 @@ from utils.access_control import (
     normalize_bot_type,
 )
 from logger_config import setup_logging, get_logger, log_action, log_error_with_context
-from app_env import get_sheet_id, get_sheet_name, render_environment_banner
+from app_env import (
+    ensure_writable_dirs,
+    get_sheet_id,
+    get_sheet_name,
+    render_environment_banner,
+)
 
 # Setup centralized logging
 setup_logging(level=logging.INFO, console_output=True, file_output=True)
@@ -89,36 +94,61 @@ st.set_page_config(
 # receives the wrong link cannot complete a graded session here by mistake.
 render_environment_banner()
 
-# --- Process failed email queue on startup ---
-# This runs once when the application starts to retry any queued emails
-try:
-    from config_loader import ConfigLoader
-    from email_utils import RobustEmailSender
-    from email_queue import EmailQueue
-    
-    config_loader = ConfigLoader()
-    config = config_loader.config
-    
-    # Check if queue processing is enabled
-    if config.get('email_config', {}).get('queue_retry_on_startup', True):
-        email_queue = EmailQueue(
-            queue_dir=config.get('logging', {}).get('smtp_log_directory', 'SMTP logs')
-        )
-        
+@st.cache_resource
+def _drain_email_queue_once() -> None:
+    """Retry any emails queued by a previous run.
+
+    Behind ``@st.cache_resource`` so it executes once per process rather than
+    on every script rerun, and called from the page body rather than at module
+    import.
+
+    That placement matters. This work performs live SMTP connections with
+    retry delays of up to 120 seconds and a 30 second connection timeout. At
+    import scope, a queue holding several entries and an unreachable mail
+    server would stall application startup for minutes before a student saw
+    anything. On MSI that becomes recurrent rather than occasional: outbound
+    access on port 587 from compute nodes is unconfirmed, and a service that
+    restarts on a walltime boundary would hang on every restart.
+
+    ``MI_SMTP_ENABLED=false`` short-circuits the send path entirely, so the
+    migration environment never reaches the network here.
+    """
+    try:
+        from config_loader import ConfigLoader
+        from email_utils import RobustEmailSender
+        from email_queue import EmailQueue
+
+        config = ConfigLoader().config
+
+        if not config.get('email_config', {}).get('queue_retry_on_startup', True):
+            return
+
+        # One-time move of anything left under the previous "SMTP logs"
+        # directory name, so pending reports are not stranded by the rename.
+        EmailQueue.migrate_legacy_dir()
+
+        email_queue = EmailQueue()
         pending_count = email_queue.get_queue_size()
-        if pending_count > 0:
-            logger.info(f"Processing {pending_count} queued emails from previous sessions")
-            
-            sender = RobustEmailSender(config)
-            result = sender.process_failed_queue()
-            
-            logger.info(
-                f"Queue processing complete: {result['succeeded']}/{result['processed']} succeeded, "
-                f"{result['still_failed']} still in queue"
-            )
-except Exception as e:
-    # Don't fail startup if queue processing fails
-    logger.warning(f"Failed to process email queue on startup: {e}")
+        if not pending_count:
+            return
+
+        logger.info(f"Processing {pending_count} queued emails from previous sessions")
+        result = RobustEmailSender(config).process_failed_queue()
+        logger.info(
+            f"Queue processing complete: {result['succeeded']}/{result['processed']} succeeded, "
+            f"{result['still_failed']} still in queue"
+        )
+    except Exception as e:
+        # A failure here must never prevent a student from starting a session.
+        logger.warning(f"Failed to process email queue: {e}")
+
+
+# Create the writable directories before anything tries to log or queue.
+# Failing here is deliberate: without them the application cannot function,
+# and discovering that at startup beats discovering it mid-session.
+ensure_writable_dirs()
+
+_drain_email_queue_once()
 
 
 

--- a/tests/test_path_externalization.py
+++ b/tests/test_path_externalization.py
@@ -1,0 +1,171 @@
+"""Guards that no runtime path depends on the process working directory.
+
+The application previously wrote to bare relative paths: ``git_logs`` for
+application logs and ``SMTP logs`` for the email retry queue, plus a bare
+``open('config.json')`` and a bare service-account filename. Those resolve
+against the working directory, which is fine only when the app is launched from
+the repository root.
+
+Two things make that unacceptable for the migration. Under Apptainer the
+application directory is read-only, so the first write fails outright. And a
+Slurm job does not necessarily start in the repository root, so even a writable
+deployment would put files somewhere unintended.
+
+Phase 8 cannot proceed until every writable path can be redirected, which is
+what these tests pin.
+"""
+
+import ast
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import app_env
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PATH_VARS = (
+    "MI_LOG_DIR",
+    "MI_QUEUE_DIR",
+    "MI_STATE_DIR",
+    "MI_CONFIG_PATH",
+    "MI_GOOGLE_SA_FILE",
+)
+
+# Modules that resolve or write runtime paths.
+PATH_AWARE_MODULES = (
+    "app_env.py",
+    "logger_config.py",
+    "email_utils.py",
+    "email_queue.py",
+    "secret_code_portal.py",
+    "utils/access_control.py",
+)
+
+
+class PathTestCase(unittest.TestCase):
+    def setUp(self):
+        self._saved = {n: os.environ.get(n) for n in PATH_VARS}
+        for n in PATH_VARS:
+            os.environ.pop(n, None)
+
+    def tearDown(self):
+        for n, v in self._saved.items():
+            if v is None:
+                os.environ.pop(n, None)
+            else:
+                os.environ[n] = v
+
+
+class TestResolversReturnAbsolutePaths(PathTestCase):
+    """Every resolver must be absolute, configured or not."""
+
+    def test_defaults_are_absolute(self):
+        for name, value in (
+            ("log dir", app_env.get_log_dir()),
+            ("queue dir", app_env.get_queue_dir()),
+            ("state dir", app_env.get_state_dir()),
+            ("config path", app_env.get_config_path()),
+            ("service account", app_env.get_google_sa_file()),
+        ):
+            with self.subTest(name=name):
+                self.assertTrue(
+                    os.path.isabs(value),
+                    f"{name} resolved to a relative path: {value}",
+                )
+
+    def test_overrides_are_absolute(self):
+        os.environ["MI_LOG_DIR"] = "/var/log/mi"
+        os.environ["MI_QUEUE_DIR"] = "/var/spool/mi"
+        self.assertTrue(os.path.isabs(app_env.get_log_dir()))
+        self.assertTrue(os.path.isabs(app_env.get_queue_dir()))
+
+    def test_a_relative_override_resolves_against_the_app_root_not_the_cwd(self):
+        """A relative value must not reintroduce working-directory dependence."""
+        os.environ["MI_LOG_DIR"] = "somewhere/logs"
+        resolved = app_env.get_log_dir()
+        self.assertTrue(os.path.isabs(resolved))
+        self.assertTrue(
+            resolved.startswith(str(REPO_ROOT)),
+            f"relative override escaped the app root: {resolved}",
+        )
+
+
+class TestOverridesAreHonoured(PathTestCase):
+    def test_each_variable_redirects_its_path(self):
+        for var, getter in (
+            ("MI_LOG_DIR", app_env.get_log_dir),
+            ("MI_QUEUE_DIR", app_env.get_queue_dir),
+            ("MI_STATE_DIR", app_env.get_state_dir),
+            ("MI_CONFIG_PATH", app_env.get_config_path),
+            ("MI_GOOGLE_SA_FILE", app_env.get_google_sa_file),
+        ):
+            with self.subTest(var=var):
+                os.environ[var] = "/tmp/mi-target"
+                self.assertEqual(getter(), os.path.abspath("/tmp/mi-target"))
+                os.environ.pop(var)
+
+
+class TestDefaultsPreserveTodaysLayout(PathTestCase):
+    """An unconfigured deployment keeps the previous directory names."""
+
+    def test_log_dir_default_is_git_logs(self):
+        self.assertEqual(os.path.basename(app_env.get_log_dir()), "git_logs")
+
+    def test_config_path_default_is_repo_config_json(self):
+        self.assertEqual(app_env.get_config_path(), str(REPO_ROOT / "config.json"))
+        self.assertTrue(os.path.exists(app_env.get_config_path()))
+
+
+class TestQueueDirectoryRename(PathTestCase):
+    """The queue directory no longer contains a space."""
+
+    def test_default_queue_dir_has_no_space(self):
+        # A space in this path had to be quoted in every shell command, Slurm
+        # script and Apptainer bind argument that referenced it.
+        self.assertNotIn(" ", os.path.basename(app_env.get_queue_dir()))
+        self.assertEqual(os.path.basename(app_env.get_queue_dir()), "smtp_queue")
+
+    def test_legacy_dir_is_still_locatable_for_migration(self):
+        # Retained for one release so queued reports are not stranded.
+        self.assertEqual(
+            os.path.basename(app_env.get_legacy_queue_dir()), "SMTP logs"
+        )
+
+
+class TestNoBareRelativePathsRemain(PathTestCase):
+    """The literals that caused the problem must not reappear in code."""
+
+    def test_no_module_opens_config_json_by_bare_name(self):
+        for module in PATH_AWARE_MODULES:
+            source = (REPO_ROOT / module).read_text(encoding="utf-8")
+            for bad in ("open('config.json'", 'open("config.json"'):
+                self.assertNotIn(
+                    bad,
+                    source,
+                    f"{module} opens config.json by bare name; use "
+                    f"app_env.get_config_path()",
+                )
+
+    def test_no_module_hardcodes_a_writable_directory_literal(self):
+        """Only app_env may name the directories, and only as defaults."""
+        for module in PATH_AWARE_MODULES:
+            if module == "app_env.py":
+                continue
+            tree = ast.parse((REPO_ROOT / module).read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                    self.assertNotIn(
+                        node.value,
+                        ("git_logs", "SMTP logs", "smtp_queue"),
+                        f"{module} line {node.lineno} hardcodes a writable "
+                        f"directory; resolve it through app_env",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/access_control.py
+++ b/utils/access_control.py
@@ -21,6 +21,8 @@ from typing import Optional, Dict, Any, Tuple
 
 import gspread
 
+from app_env import get_google_sa_file
+
 logger = logging.getLogger(__name__)
 
 # Role constants
@@ -225,7 +227,10 @@ def get_sheet_client(
     creds_dict = None
     creds_source = None
     service_account_email = None
-    service_account_file = "umnsod-mibot-ea3154b145f1.json"
+    # Absolute, and overridable with MI_GOOGLE_SA_FILE. Previously a bare
+    # relative filename, so whether it was found depended on the process
+    # working directory.
+    service_account_file = get_google_sa_file()
     
     # Get streamlit secrets if not provided
     if streamlit_secrets is None:


### PR DESCRIPTION
## Plan reference

`docs/MIGRATION_PLAN.md` section 10. **Hard prerequisite for Phase 8**: Apptainer mounts the application directory read-only, so every bare relative write fails on the first attempt.

## The problem

The application wrote to paths resolved against the **process working directory**:

| Path | Used for |
|---|---|
| `git_logs` | application logs |
| `SMTP logs` | email retry queue, including student PDFs on failure |
| `open('config.json')` | configuration, opened by bare name |
| `umnsod-mibot-...json` | service account, bare filename |

That works only when the app is launched from the repository root, which a Slurm job does not guarantee, and fails outright on a read-only container filesystem.

## What changed

`app_env` now resolves five variables, each returning an **absolute** path and defaulting to a location beside `app_env.py`, so an unconfigured deployment keeps today's layout:

`MI_LOG_DIR`, `MI_QUEUE_DIR`, `MI_STATE_DIR`, `MI_CONFIG_PATH`, `MI_GOOGLE_SA_FILE`

A **relative** override resolves against the application root, not the working directory, since that dependence is precisely what is being removed.

`MI_STATE_DIR` is added now although Phase 7 consumes it, so the path layer is complete in one change rather than revisited.

## The directory with a space

`SMTP logs` becomes `smtp_queue`. That space had to be quoted in every shell command, Slurm script and Apptainer bind argument that referenced it.

`EmailQueue.migrate_legacy_dir()` moves anything left under the old name on first run, refusing to overwrite an existing entry. Without it, **any report queued at the moment this deploys would never be sent.**

## Resolution happens at call time, not import time

`logger_config` would naturally have bound the directory into a module constant. That freezes whatever `MI_LOG_DIR` happened to be when the module was first imported, which is the same trap that made `SessionConfig`'s model defaults unconfigurable in Phase 3. Caught here rather than after.

## The startup hang

The email queue drain ran **at module import scope**. It performs live SMTP connections with retry delays up to 120s and a 30s connection timeout, so a queue with several entries and an unreachable mail server stalled application startup for minutes before a student saw anything.

On MSI that would become recurrent rather than occasional: outbound port 587 from compute nodes is unconfirmed (Help Desk question B4), and a service restarting on a walltime boundary would hang on **every** restart.

It now sits behind `@st.cache_resource`, called from the page body.

## config.json

Dropped `log_directory`, `log_file` and `smtp_log_directory`. Keeping path keys in a config file that is itself located by a path is circular, and they were bare relative values.

## Tests

`tests/test_path_externalization.py` pins absoluteness, override behaviour, the no-space rename, and an **AST check that no module outside `app_env` hardcodes a writable directory literal**, so the pattern cannot creep back.

## Verification for reviewers

The real acceptance test is starting from a foreign working directory:

```bash
cd / && MI_LOG_DIR=/tmp/mi/logs MI_QUEUE_DIR=/tmp/mi/queue \
  python -m streamlit run /abs/path/secret_code_portal.py
```

## Merge gates

| Gate | Status |
|---|---|
| CI | Pending |
| Production untouched | Targets `msi-hybrid` |
| Plan reference | Section 10 |
| Ordering | Unblocks Phase 8 |

## Rollback

All defaults preserve current behaviour when the variables are unset. The one behavioural change that persists is the queue directory rename, which is why the legacy migration ships with it.